### PR TITLE
Add XML digital signature to metadata generation

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,7 @@ gem 'aaf-gumboot', git: 'https://github.com/ausaccessfed/aaf-gumboot.git',
                    branch: 'develop'
 gem 'accession'
 gem 'nokogiri', '~> 1.6.5'
+gem 'xmldsig'
 
 gem 'resque'
 gem 'resque-retry'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -335,6 +335,8 @@ GEM
     webmock (1.20.4)
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
+    xmldsig (0.2.6)
+      nokogiri
     xpath (2.0.0)
       nokogiri (~> 1.3)
 
@@ -375,3 +377,4 @@ DEPENDENCIES
   uglifier (>= 1.3.0)
   unicorn
   webmock
+  xmldsig

--- a/Guardfile
+++ b/Guardfile
@@ -14,6 +14,7 @@ guard :rspec, cmd: 'bundle exec rspec' do
   watch(%r{^spec/factories/(.+)\.rb$})                { "spec/support/factories_spec.rb" }
 
   watch(%r{^spec/.+_spec\.rb$})
+  watch(%r{^spec/support/metadata/.+\.rb$})           { 'spec/metadata' }
   watch(%r{^app/(.+)\.rb$})                           { |m| "spec/#{m[1]}_spec.rb" }
   watch(%r{^lib/(.+)\.rb$})                           { |m| "spec/#{m[1]}_spec.rb" }
   watch(%r{^app/(.*)(\.erb|\.haml|\.slim)$})          { |m| "spec/#{m[1]}#{m[2]}_spec.rb" }

--- a/Guardfile
+++ b/Guardfile
@@ -2,11 +2,6 @@ guard :bundler do
   watch('Gemfile')
 end
 
-guard :rubocop do
-  watch(%r{.+\.rb$})
-  watch(%r{(?:.+/)?\.rubocop\.yml$}) { |m| File.dirname(m[0]) }
-end
-
 guard :rspec, cmd: 'bundle exec rspec' do
   watch('spec/spec_helper.rb')                        { "spec" }
   watch('config/routes.rb')                           { "spec/routing" }
@@ -20,6 +15,11 @@ guard :rspec, cmd: 'bundle exec rspec' do
   watch(%r{^app/(.*)(\.erb|\.haml|\.slim)$})          { |m| "spec/#{m[1]}#{m[2]}_spec.rb" }
   watch(%r{^lib/(.+)\.rb$})                           { |m| "spec/lib/#{m[1]}_spec.rb" }
   watch(%r{^app/controllers/(.+)_(controller)\.rb$})  { |m| ["spec/routing/#{m[1]}_routing_spec.rb", "spec/#{m[2]}s/#{m[1]}_#{m[2]}_spec.rb", "spec/acceptance/#{m[1]}_spec.rb"] }
+end
+
+guard :rubocop do
+  watch(%r{.+\.rb$})
+  watch(%r{(?:.+/)?\.rubocop\.yml$}) { |m| File.dirname(m[0]) }
 end
 
 guard :brakeman, quiet: true do

--- a/app/models/entity_source.rb
+++ b/app/models/entity_source.rb
@@ -26,8 +26,12 @@ class EntitySource < Sequel::Model
   def validate_certificate
     return if certificate.nil?
 
-    OpenSSL::X509::Certificate.new(certificate)
+    x509_certificate
   rescue OpenSSL::X509::CertificateError
     errors.add(:certificate, 'is not a valid PEM format X.509 certificate')
+  end
+
+  def x509_certificate
+    certificate && OpenSSL::X509::Certificate.new(certificate)
   end
 end

--- a/app/models/keypair.rb
+++ b/app/models/keypair.rb
@@ -1,0 +1,34 @@
+class Keypair < Sequel::Model
+  def validate
+    super
+
+    validates_presence [:certificate, :key]
+    validates_max_length 4096, [:certificate, :key]
+
+    validate_keypair_content
+  end
+
+  def validate_keypair_content
+    cert = validate_certificate
+    key = validate_key
+
+    return if cert.nil? || key.nil?
+    return if cert.public_key.params == key.public_key.params
+
+    errors.add(:certificate, 'does not match the private key')
+  end
+
+  def validate_certificate
+    OpenSSL::X509::Certificate.new(certificate)
+  rescue OpenSSL::X509::CertificateError
+    errors.add(:certificate, 'is not a valid X.509 certificate')
+    nil
+  end
+
+  def validate_key
+    OpenSSL::PKey::RSA.new(key)
+  rescue OpenSSL::PKey::RSAError
+    errors.add(:key, 'is not a valid RSA key')
+    nil
+  end
+end

--- a/app/models/metadata_instance.rb
+++ b/app/models/metadata_instance.rb
@@ -8,8 +8,10 @@ class MetadataInstance < Sequel::Model
 
   def validate
     super
-    validates_presence [:name, :created_at, :updated_at]
+    validates_presence [:name, :created_at, :updated_at, :hash_algorithm]
     validates_presence :ca_verify_depth if ca_key_infos.present?
     validates_presence :publication_info unless new?
+
+    validates_includes %w(sha1 sha256), :hash_algorithm
   end
 end

--- a/app/models/metadata_instance.rb
+++ b/app/models/metadata_instance.rb
@@ -1,4 +1,6 @@
 class MetadataInstance < Sequel::Model
+  many_to_one :keypair
+
   one_to_many :entity_descriptors
   one_to_many :ca_key_infos
 
@@ -8,7 +10,8 @@ class MetadataInstance < Sequel::Model
 
   def validate
     super
-    validates_presence [:name, :created_at, :updated_at, :hash_algorithm]
+    validates_presence [:name, :created_at, :updated_at, :hash_algorithm,
+                        :keypair]
     validates_presence :ca_verify_depth if ca_key_infos.present?
     validates_presence :publication_info unless new?
 

--- a/db/migrate/20150304031737_add_hash_algorithm_to_metadata_instance.rb
+++ b/db/migrate/20150304031737_add_hash_algorithm_to_metadata_instance.rb
@@ -1,0 +1,7 @@
+Sequel.migration do
+  change do
+    alter_table :metadata_instances do
+      add_column :hash_algorithm, String, null: false
+    end
+  end
+end

--- a/db/migrate/20150305210958_create_keypairs.rb
+++ b/db/migrate/20150305210958_create_keypairs.rb
@@ -1,0 +1,9 @@
+Sequel.migration do
+  change do
+    create_table :keypairs do
+      primary_key :id
+      String :certificate, null: false, size: 4096
+      String :key, null: false, size: 4096
+    end
+  end
+end

--- a/db/migrate/20150305230517_add_keypair_to_metadata_instances.rb
+++ b/db/migrate/20150305230517_add_keypair_to_metadata_instances.rb
@@ -1,0 +1,7 @@
+Sequel.migration do
+  change do
+    alter_table :metadata_instances do
+      add_foreign_key :keypair_id, :keypairs, null: false
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -95,6 +95,7 @@ Sequel.migration do
       column :created_at, "datetime"
       column :updated_at, "datetime"
       column :ca_verify_depth, "int(11)"
+      column :hash_algorithm, "varchar(255)", :null=>false
     end
     
     create_table(:organizations) do
@@ -758,5 +759,6 @@ Sequel.migration do
     self << "INSERT INTO `schema_migrations` (`filename`) VALUES ('20150223223047_add_url_to_entity_source.rb')"
     self << "INSERT INTO `schema_migrations` (`filename`) VALUES ('20150226001416_add_sp_sso_descriptor_foreign_key_to_discovery_response_services.rb')"
     self << "INSERT INTO `schema_migrations` (`filename`) VALUES ('20150226030540_add_certificate_to_entity_sources.rb')"
+    self << "INSERT INTO `schema_migrations` (`filename`) VALUES ('20150304031737_add_hash_algorithm_to_metadata_instance.rb')"
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -93,17 +93,6 @@ Sequel.migration do
       column :updated_at, "datetime"
     end
     
-    create_table(:metadata_instances) do
-      primary_key :id, :type=>"int(11)"
-      column :identifier, "varchar(255)"
-      column :name, "varchar(255)", :null=>false
-      column :extensions, "text"
-      column :created_at, "datetime"
-      column :updated_at, "datetime"
-      column :ca_verify_depth, "int(11)"
-      column :hash_algorithm, "varchar(255)", :null=>false
-    end
-    
     create_table(:organizations) do
       primary_key :id, :type=>"int(11)"
       column :url, "varchar(255)", :null=>false
@@ -155,13 +144,6 @@ Sequel.migration do
       index [:sso_descriptor_id], :name=>:sso_ars_fkey
     end
     
-    create_table(:ca_key_infos) do
-      primary_key :id, :type=>"int(11)"
-      foreign_key :metadata_instance_id, :metadata_instances, :type=>"int(11)", :key=>[:id]
-      
-      index [:metadata_instance_id], :name=>:ca_key_infos_mi_id_fk
-    end
-    
     create_table(:entity_descriptors) do
       primary_key :id, :type=>"int(11)"
       foreign_key :organization_id, :organizations, :type=>"int(11)", :key=>[:id]
@@ -179,6 +161,20 @@ Sequel.migration do
       foreign_key :sso_descriptor_id, :sso_descriptors, :type=>"int(11)", :key=>[:id]
       
       index [:sso_descriptor_id], :name=>:sso_mnid_fkey
+    end
+    
+    create_table(:metadata_instances) do
+      primary_key :id, :type=>"int(11)"
+      column :identifier, "varchar(255)"
+      column :name, "varchar(255)", :null=>false
+      column :extensions, "text"
+      column :created_at, "datetime"
+      column :updated_at, "datetime"
+      column :ca_verify_depth, "int(11)"
+      column :hash_algorithm, "varchar(255)", :null=>false
+      foreign_key :keypair_id, :keypairs, :type=>"int(11)", :null=>false, :key=>[:id]
+      
+      index [:keypair_id], :name=>:keypair_id
     end
     
     create_table(:organization_display_names) do
@@ -259,6 +255,13 @@ Sequel.migration do
       foreign_key :entity_descriptor_id, :entity_descriptors, :type=>"int(11)", :key=>[:id]
       
       index [:entity_descriptor_id], :name=>:ed_aad_fkey
+    end
+    
+    create_table(:ca_key_infos) do
+      primary_key :id, :type=>"int(11)"
+      foreign_key :metadata_instance_id, :metadata_instances, :type=>"int(11)", :key=>[:id]
+      
+      index [:metadata_instance_id], :name=>:ca_key_infos_mi_id_fk
     end
     
     create_table(:entity_attributes) do
@@ -767,5 +770,6 @@ Sequel.migration do
     self << "INSERT INTO `schema_migrations` (`filename`) VALUES ('20150226030540_add_certificate_to_entity_sources.rb')"
     self << "INSERT INTO `schema_migrations` (`filename`) VALUES ('20150304031737_add_hash_algorithm_to_metadata_instance.rb')"
     self << "INSERT INTO `schema_migrations` (`filename`) VALUES ('20150305210958_create_keypairs.rb')"
+    self << "INSERT INTO `schema_migrations` (`filename`) VALUES ('20150305230517_add_keypair_to_metadata_instances.rb')"
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -62,6 +62,12 @@ Sequel.migration do
       column :updated_at, "datetime"
     end
     
+    create_table(:keypairs) do
+      primary_key :id, :type=>"int(11)"
+      column :certificate, "varchar(4096)", :null=>false
+      column :key, "varchar(4096)", :null=>false
+    end
+    
     create_table(:known_entities) do
       primary_key :id, :type=>"int(11)"
       column :entity_id, "varchar(255)", :null=>false
@@ -760,5 +766,6 @@ Sequel.migration do
     self << "INSERT INTO `schema_migrations` (`filename`) VALUES ('20150226001416_add_sp_sso_descriptor_foreign_key_to_discovery_response_services.rb')"
     self << "INSERT INTO `schema_migrations` (`filename`) VALUES ('20150226030540_add_certificate_to_entity_sources.rb')"
     self << "INSERT INTO `schema_migrations` (`filename`) VALUES ('20150304031737_add_hash_algorithm_to_metadata_instance.rb')"
+    self << "INSERT INTO `schema_migrations` (`filename`) VALUES ('20150305210958_create_keypairs.rb')"
   end
 end

--- a/lib/metadata/saml.rb
+++ b/lib/metadata/saml.rb
@@ -35,6 +35,10 @@ module Metadata
                      "#{created_at.to_formatted_s(:number)}"
     end
 
+    def sign(key)
+      Xmldsig::SignedDocument.new(builder.doc).sign(key)
+    end
+
     def entities_descriptor(known_entities)
       attributes = { ID: instance_id,
                      Name: metadata_name,

--- a/lib/metadata/saml.rb
+++ b/lib/metadata/saml.rb
@@ -66,18 +66,31 @@ module Metadata
     end
 
     C14N_METHOD = 'http://www.w3.org/2001/10/xml-exc-c14n#'
-    SIGNATURE_METHOD = 'http://www.w3.org/2000/09/xmldsig#rsa-sha1'
     TRANSFORM_METHODS = %w(
       http://www.w3.org/2000/09/xmldsig#enveloped-signature
       http://www.w3.org/2001/10/xml-exc-c14n#
     )
-    DIGEST_METHOD = 'http://www.w3.org/2000/09/xmldsig#sha1'
+
+    SIGNATURE_METHOD = {
+      sha1: 'http://www.w3.org/2000/09/xmldsig#rsa-sha1',
+      sha256: 'http://www.w3.org/2001/04/xmldsig-more#rsa-sha256'
+    }.with_indifferent_access
+
+    DIGEST_METHOD = {
+      sha1: 'http://www.w3.org/2000/09/xmldsig#sha1',
+      sha256: 'http://www.w3.org/2001/04/xmlenc#sha256'
+    }.with_indifferent_access
+
+    private_constant :C14N_METHOD, :TRANSFORM_METHODS, :SIGNATURE_METHOD,
+                     :DIGEST_METHOD
 
     def signature_element
+      hash_algorithm = metadata_instance.hash_algorithm
+
       ds.Signature do
         ds.SignedInfo do
           ds.CanonicalizationMethod(Algorithm: C14N_METHOD)
-          ds.SignatureMethod(Algorithm: SIGNATURE_METHOD)
+          ds.SignatureMethod(Algorithm: SIGNATURE_METHOD[hash_algorithm])
 
           ds.Reference(URI: "##{instance_id}") do
             ds.Transforms do
@@ -86,7 +99,7 @@ module Metadata
               end
             end
 
-            ds.DigestMethod(Algorithm: DIGEST_METHOD)
+            ds.DigestMethod(Algorithm: DIGEST_METHOD[hash_algorithm])
             ds.DigestValue('')
           end
         end

--- a/lib/metadata/saml.rb
+++ b/lib/metadata/saml.rb
@@ -6,7 +6,7 @@ module Metadata
 
     attr_reader :builder, :created_at, :expires_at, :instance_id,
                 :federation_identifier, :metadata_name, :metadata_instance,
-                :metadata_validity_period, :certificate
+                :metadata_validity_period
 
     protected
 
@@ -19,6 +19,14 @@ module Metadata
       attr.attribute_values.each do |attr_val|
         attribute_value(attr_val)
       end
+    end
+
+    def certificate
+      OpenSSL::X509::Certificate.new(metadata_instance.keypair.certificate)
+    end
+
+    def key
+      OpenSSL::PKey::RSA.new(metadata_instance.keypair.key)
     end
 
     public
@@ -35,7 +43,7 @@ module Metadata
                      "#{created_at.to_formatted_s(:number)}"
     end
 
-    def sign(key)
+    def sign
       Xmldsig::SignedDocument.new(builder.doc).sign(key)
     end
 

--- a/lib/metadata/saml.rb
+++ b/lib/metadata/saml.rb
@@ -109,8 +109,8 @@ module Metadata
         ds.KeyInfo do
           ds.KeyValue do
             ds.RSAKeyValue do
-              ds.Modulus(bn_base64(certificate.public_key.n))
-              ds.Exponent(bn_base64(certificate.public_key.e))
+              ds.Modulus(openssl_bn_to_base64(certificate.public_key.n))
+              ds.Exponent(openssl_bn_to_base64(certificate.public_key.e))
             end
           end
 
@@ -538,7 +538,7 @@ module Metadata
       end
     end
 
-    def bn_base64(bn)
+    def openssl_bn_to_base64(bn)
       Base64.strict_encode64([bn.to_s(16)].pack('H*'))
     end
   end

--- a/lib/metadata/saml.rb
+++ b/lib/metadata/saml.rb
@@ -99,11 +99,11 @@ module Metadata
               ds.Modulus(bn_base64(certificate.public_key.n))
               ds.Exponent(bn_base64(certificate.public_key.e))
             end
+          end
 
-            ds.X509Data do
-              b64 = Base64.strict_encode64(certificate.to_der)
-              ds.X509Certificate(b64.scan(/.{1,64}/).join("\n"))
-            end
+          ds.X509Data do
+            b64 = Base64.strict_encode64(certificate.to_der)
+            ds.X509Certificate(b64.scan(/.{1,64}/).join("\n"))
           end
         end
       end

--- a/spec/factories/key_infos.rb
+++ b/spec/factories/key_infos.rb
@@ -4,8 +4,14 @@ FactoryGirl.define do
   subject = "CN=#{Faker::Lorem.word}/DC=#{Faker::Lorem.word}"
   issuer = "CN=#{Faker::Lorem.word}/DC=#{Faker::Lorem.word}"
   trait :base_key_info do
-    expiry Time.now + 3600
-    data { generate_certificate subject }
+    transient do
+      certificate do
+        create(:certificate, subject_dn: subject, issuer_dn: issuer)
+      end
+    end
+
+    expiry { certificate.not_after }
+    data { certificate.to_pem }
   end
 
   trait :with_name do
@@ -28,28 +34,4 @@ FactoryGirl.define do
   factory :key_info do
     base_key_info
   end
-end
-
-def generate_certificate(subject)
-  key = OpenSSL::PKey::RSA.new(1024)
-  public_key = key.public_key
-
-  cert = OpenSSL::X509::Certificate.new
-  cert.subject = cert.issuer = OpenSSL::X509::Name.parse(subject)
-  cert.public_key = public_key
-  specify_certificate_defaults cert
-
-  cert.sign key, OpenSSL::Digest::SHA1.new
-  cert.to_pem
-end
-
-def specify_certificate_defaults(cert)
-  cert.not_before = Time.now
-  cert.not_after = Time.now + 3600
-  cert.serial = 0x0
-  cert.version = 2
-end
-
-def generate_key
-  OpenSSL::PKey::RSA.new 1024
 end

--- a/spec/factories/keypair.rb
+++ b/spec/factories/keypair.rb
@@ -1,0 +1,43 @@
+FactoryGirl.define do
+  TEST_RSA_KEYS = {}
+
+  factory :rsa_key, class: OpenSSL::PKey::RSA do
+    transient { bits 2048 }
+
+    initialize_with do
+      TEST_RSA_KEYS[bits.to_i] ||= OpenSSL::PKey::RSA.new(bits)
+    end
+
+    skip_create
+  end
+
+  factory :certificate, class: OpenSSL::X509::Certificate do
+    transient do
+      rsa_key { create(:rsa_key) }
+      dn { "CN=#{SecureRandom.urlsafe_base64}" }
+      digest_class OpenSSL::Digest::SHA256
+    end
+
+    public_key { rsa_key.public_key }
+    issuer { OpenSSL::X509::Name.parse(dn) }
+    subject { issuer }
+
+    not_before { Time.now }
+    not_after { 1.hour.from_now }
+    serial 0
+    version 2
+
+    after(:build) do |cert, attr|
+      cert.sign(attr.rsa_key, attr.digest_class.new)
+    end
+
+    skip_create
+  end
+
+  factory :keypair do
+    transient { rsa_key { create(:rsa_key) } }
+
+    certificate { create(:certificate, rsa_key: rsa_key).to_pem }
+    key { rsa_key.to_pem }
+  end
+end

--- a/spec/factories/keypair.rb
+++ b/spec/factories/keypair.rb
@@ -14,13 +14,14 @@ FactoryGirl.define do
   factory :certificate, class: OpenSSL::X509::Certificate do
     transient do
       rsa_key { create(:rsa_key) }
-      dn { "CN=#{SecureRandom.urlsafe_base64}" }
+      subject_dn { "CN=#{SecureRandom.urlsafe_base64}" }
+      issuer_dn { subject_dn }
       digest_class OpenSSL::Digest::SHA256
     end
 
     public_key { rsa_key.public_key }
-    issuer { OpenSSL::X509::Name.parse(dn) }
-    subject { issuer }
+    issuer { OpenSSL::X509::Name.parse(issuer_dn) }
+    subject { OpenSSL::X509::Name.parse(subject_dn) }
 
     not_before { Time.now }
     not_after { 1.hour.from_now }

--- a/spec/factories/metadata_instances.rb
+++ b/spec/factories/metadata_instances.rb
@@ -1,5 +1,7 @@
 FactoryGirl.define do
   factory :metadata_instance do
+    association :keypair
+
     name { Faker::Internet.domain_name }
     hash_algorithm 'sha256'
 

--- a/spec/factories/metadata_instances.rb
+++ b/spec/factories/metadata_instances.rb
@@ -1,6 +1,7 @@
 FactoryGirl.define do
   factory :metadata_instance do
     name { Faker::Internet.domain_name }
+    hash_algorithm 'sha256'
 
     after :create do | mi |
       create(:mdrpi_publication_info, metadata_instance: mi)

--- a/spec/jobs/update_entity_source_spec.rb
+++ b/spec/jobs/update_entity_source_spec.rb
@@ -11,26 +11,8 @@ RSpec.describe UpdateEntitySource do
     doc.xpath('//*[local-name() = "EntityDescriptor"]/@entityID').map(&:value)
   end
 
-  before(:all) { @key = OpenSSL::PKey::RSA.new(1024) }
-
-  let(:key) { @key }
-
-  let(:certificate) do
-    cert = OpenSSL::X509::Certificate.new
-
-    cert.subject = cert.issuer =
-      OpenSSL::X509::Name.parse("CN=#{SecureRandom.urlsafe_base64}")
-
-    cert.public_key = key.public_key
-
-    cert.not_before = Time.now
-    cert.not_after = Time.now + 3600
-    cert.serial = 0x0
-    cert.version = 2
-
-    cert.sign key, OpenSSL::Digest::SHA1.new
-    cert
-  end
+  let(:key) { create(:rsa_key) }
+  let(:certificate) { create(:certificate, rsa_key: key) }
 
   def swallow
     yield

--- a/spec/jobs/update_entity_source_spec.rb
+++ b/spec/jobs/update_entity_source_spec.rb
@@ -1,13 +1,35 @@
 require 'rails_helper'
 
 RSpec.describe UpdateEntitySource do
-  subject { create(:entity_source, :external) }
+  subject { create(:entity_source, :external, certificate: certificate.to_pem) }
   before { stub_request(:get, subject.url).to_return(response) }
-  let(:response) { { status: 200, headers: {}, body: xml } }
+  let(:response) { { status: 200, headers: {}, body: signed_xml } }
   let(:doc) { Nokogiri::XML.parse(xml) }
+  let(:signed_xml) { Xmldsig::SignedDocument.new(xml).sign(key) }
 
   let(:entity_ids) do
     doc.xpath('//*[local-name() = "EntityDescriptor"]/@entityID').map(&:value)
+  end
+
+  before(:all) { @key = OpenSSL::PKey::RSA.new(1024) }
+
+  let(:key) { @key }
+
+  let(:certificate) do
+    cert = OpenSSL::X509::Certificate.new
+
+    cert.subject = cert.issuer =
+      OpenSSL::X509::Name.parse("CN=#{SecureRandom.urlsafe_base64}")
+
+    cert.public_key = key.public_key
+
+    cert.not_before = Time.now
+    cert.not_after = Time.now + 3600
+    cert.serial = 0x0
+    cert.version = 2
+
+    cert.sign key, OpenSSL::Digest::SHA1.new
+    cert
   end
 
   def swallow
@@ -29,9 +51,37 @@ RSpec.describe UpdateEntitySource do
     fragments.join("\n")
   end
 
+  EMPTY_SIGNATURE = <<-EOF.strip_heredoc
+    <ds:Signature xmlns:ds="http://www.w3.org/2000/09/xmldsig#">
+      <ds:SignedInfo>
+        <ds:CanonicalizationMethod
+          Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"/>
+        <ds:SignatureMethod
+          Algorithm="http://www.w3.org/2001/04/xmldsig-more#rsa-sha256"/>
+
+        <ds:Reference URI="#_x">
+          <ds:Transforms>
+            <ds:Transform Algorithm=
+              "http://www.w3.org/2000/09/xmldsig#enveloped-signature" />
+            <ds:Transform
+              Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"/>
+          </ds:Transforms>
+
+          <ds:DigestMethod
+            Algorithm="http://www.w3.org/2001/04/xmlenc#sha256"/>
+          <ds:DigestValue></ds:DigestValue>
+        </ds:Reference>
+      </ds:SignedInfo>
+
+      <ds:SignatureValue></ds:SignatureValue>
+    </ds:Signature>
+  EOF
+
   def entities_descriptor(fore: nil, entities:)
     [
-      '<EntitiesDescriptor xmlns="urn:oasis:names:tc:SAML:2.0:metadata">',
+      '<EntitiesDescriptor xmlns="urn:oasis:names:tc:SAML:2.0:metadata" ',
+      'ID="_x">',
+      EMPTY_SIGNATURE.indent(2),
       fore,
       entity_descriptors(entities: entities).indent(2),
       '</EntitiesDescriptor>'
@@ -64,7 +114,7 @@ RSpec.describe UpdateEntitySource do
     it 'sets the xml for the raw entity descriptor' do
       run
       expect(subject.known_entities.last.raw_entity_descriptor.xml)
-        .to eq(Nokogiri::XML.parse(xml).root.elements[0].canonicalize)
+        .to eq(Nokogiri::XML.parse(xml).root.elements[1].canonicalize)
     end
 
     context 'when the entity already exists' do
@@ -110,7 +160,7 @@ RSpec.describe UpdateEntitySource do
         end
 
         it 'updates the raw entity descriptor' do
-          new_xml = Nokogiri::XML.parse(xml).root.elements[0].canonicalize
+          new_xml = Nokogiri::XML.parse(xml).root.elements[1].canonicalize
           expect { run }.to change { red.reload.xml }.from(old_xml).to(new_xml)
         end
       end
@@ -199,8 +249,7 @@ RSpec.describe UpdateEntitySource do
 
   context 'with invalid xml' do
     let(:xml) do
-      entities_descriptor(entities: 1)
-        .gsub(/entityID="[^"]+"/, '')
+      entities_descriptor(entities: 1) .gsub(/entityID="[^"]+"/, '')
     end
 
     it 'creates no records' do
@@ -247,11 +296,10 @@ RSpec.describe UpdateEntitySource do
     end
   end
 
-  context 'with an invalid signature', pending: 'Not implemented yet' do
-    let(:signature) { '' } # TODO
-    let(:xml) do
-      entities_descriptor(fore: signature, entities: 1)
-    end
+  context 'with an invalid signature' do
+    let(:wrong_key) { OpenSSL::PKey::RSA.new(1024) }
+    let(:xml) { entities_descriptor(entities: 1) }
+    let(:signed_xml) { Xmldsig::SignedDocument.new(xml).sign(wrong_key) }
 
     it 'raises an informative message' do
       swallow { run }

--- a/spec/metadata/saml_spec.rb
+++ b/spec/metadata/saml_spec.rb
@@ -21,26 +21,8 @@ RSpec.describe Metadata::SAML do
     create(:metadata_instance, hash_algorithm: hash_algorithm)
   end
 
-  before(:all) { @key = OpenSSL::PKey::RSA.new(1024) }
-
-  let(:key) { @key }
-
-  let(:certificate) do
-    cert = OpenSSL::X509::Certificate.new
-
-    cert.subject = cert.issuer =
-      OpenSSL::X509::Name.parse("CN=#{SecureRandom.urlsafe_base64}")
-
-    cert.public_key = key.public_key
-
-    cert.not_before = Time.now
-    cert.not_after = Time.now + 3600
-    cert.serial = 0x0
-    cert.version = 2
-
-    cert.sign key, OpenSSL::Digest::SHA1.new
-    cert
-  end
+  let(:key) { create(:rsa_key) }
+  let(:certificate) { create(:certificate, rsa_key: key) }
 
   let(:builder) { subject.builder }
   let(:raw_xml) { builder.to_xml }

--- a/spec/metadata/saml_spec.rb
+++ b/spec/metadata/saml_spec.rb
@@ -7,8 +7,7 @@ RSpec.describe Metadata::SAML do
     Metadata::SAML.new(metadata_instance: metadata_instance,
                        federation_identifier: federation_identifier,
                        metadata_name: metadata_name,
-                       metadata_validity_period: metadata_validity_period,
-                       certificate: certificate)
+                       metadata_validity_period: metadata_validity_period)
   end
 
   let(:federation_identifier) { Faker::Internet.domain_word }
@@ -20,9 +19,6 @@ RSpec.describe Metadata::SAML do
   let(:metadata_instance) do
     create(:metadata_instance, hash_algorithm: hash_algorithm)
   end
-
-  let(:key) { create(:rsa_key) }
-  let(:certificate) { create(:certificate, rsa_key: key) }
 
   let(:builder) { subject.builder }
   let(:raw_xml) { builder.to_xml }

--- a/spec/metadata/saml_spec.rb
+++ b/spec/metadata/saml_spec.rb
@@ -14,8 +14,12 @@ RSpec.describe Metadata::SAML do
   let(:federation_identifier) { Faker::Internet.domain_word }
   let(:metadata_name) { "urn:mace:#{federation_identifier}.edu:test" }
   let(:metadata_validity_period) { 1.weeks }
-  let(:metadata_instance) { create(:metadata_instance) }
   let(:entity_descriptors) { entity_source.entity_descriptors }
+  let(:hash_algorithm) { 'sha256' }
+
+  let(:metadata_instance) do
+    create(:metadata_instance, hash_algorithm: hash_algorithm)
+  end
 
   before(:all) { @key = OpenSSL::PKey::RSA.new(1024) }
 

--- a/spec/models/entity_source_spec.rb
+++ b/spec/models/entity_source_spec.rb
@@ -1,6 +1,15 @@
 require 'rails_helper'
 
 RSpec.describe EntitySource do
+  def pem_jumble(pem)
+    parts = pem.split("\n").map do |s|
+      next s if s.start_with?('-----') || s.start_with?('MII')
+      s.reverse
+    end
+
+    parts.join("\n")
+  end
+
   subject { build(:entity_source) }
 
   it_behaves_like 'a basic model'
@@ -73,51 +82,6 @@ RSpec.describe EntitySource do
     end
   end
 
-  let(:valid_cert) do
-    <<-EOF.gsub(/^\s+/, '')
-      -----BEGIN CERTIFICATE-----
-      MIIDEjCCAfqgAwIBAwIGAUt1eu5UMA0GCSqGSIb3DQEBCwUAMDMxMTAvBgNVBAMM
-      KEZvLUhoc1RzaHZNOG1HR25uQXRRaEE2NFNuUnNfMDI3NElFRjdkYnIwHhcNMTUw
-      MjEwMjE1MjQ1WhcNMTUwMjEwMjIwMjQ1WjAzMTEwLwYDVQQDDChGby1IaHNUc2h2
-      TThtR0dubkF0UWhBNjRTblJzXzAyNzRJRUY3ZGJyMIIBIjANBgkqhkiG9w0BAQEF
-      AAOCAQ8AMIIBCgKCAQEA0pyyFLVsbKJpr1MAS5ofZPz1R+uvbq1ySvBPlMRZNsOO
-      LxW/YE690xPFcUA47KYZdjHhgUx2lyzPRzARn6gRIR+QY2ujC1g+eEUFth4JSi0/
-      KhHoKLm20XYy1k3G11XA8Nh8/IBvZxHIPHl/8UAgr++nGH+6rnWRAEXrha02WXJO
-      Tyus6+x6311O8Yw5bP7L3RKjBs1qg8V0NKfDVbjSvohAYWIOZHN3+rCEHcAAhsuZ
-      ezX00uzdq29OSGxUx02xxHYpnYacj0PTm5d45HDolRkra7bp9YABOsGHkVC41qn8
-      AM8w8yyapqOVHbe1Gu7x66OkKf5yCq9KMBLOAEkxmwIDAQABoywwKjAJBgNVHRME
-      AjAAMB0GA1UdDgQWBBSseRpNDC0YSFARQoGwm28iq6MsnjANBgkqhkiG9w0BAQsF
-      AAOCAQEAGDD4KhlSl7rzDpu2XUx3/5bvBeybv0b5OsK7XCuwrxBTFlxnp9ilAp4d
-      oL6WltlDG9ySiyvjx31AMXKsghTSQcMPUI4noAMUH4XkE0m3sfxuQPY4lBUEaiNB
-      gNFst7+HCXQ0Nhmg3mhtNvoilC1l5h2pZyn/X/ZCUb/2cvPIM54PrHUEU760f0R8
-      KNeFL5E8z2Jsf0YqmqwboIdWLubCZzyL7uPrNa3lejQnAwILuH7p7fbALuFqlw4R
-      PNanaejYZSiFt6WhgEnZFBIQWOm8bIisaDrZDIWDoV95GQ22XwggoQljAgQMcSBF
-      GBin3WhsAuXzHCJIuCo1tjvt/O65UQ==
-      -----END CERTIFICATE-----
-    EOF
-  end
-
-  let(:invalid_cert) do
-    <<-EOF.gsub(/^\s+/, '')
-      -----BEGIN CERTIFICATE-----
-      MIIDEjCCAFQGaWibaWigauT1EU5uma0gcsQgsiB3dqebcWuamdmXmtaVbGnvbamm
-      kezVluHOC1rZAhznog1hr25UqxrrAee2nfnUuNnFmdi3neLfrJDKyNiWhHCnmtuW
-      mJeWmJe1mJq1wHCnmtuWmJeWmJiWmJq1wJaZmteWlWydvqqddcHgBY1iAhnuC2H2
-      ttHTr0DUBKf0uwHbnJrtBLjZxZaYnZrjruy3zgjYmiibiJanbGKQHKIg9W0baqef
-      aaocaq8amiibcGkcaqea0PYYflvSBkjPR1mas5OFzpZ1r+UVBQ1YsVbpLmrznSoo
-      lXw/ye690XpfCua47kyzDJhHGuX2LYZprZarN6Grir+qy2UJc1G+EeufTH4jsI0/
-      kHhOklM20xyY1K3g11xa8nH8/ibVzXhiphL/8uaGR++Ngh+6RNwraexRHA02wxjo
-      tYUS6+X6311o8yW5Bp7l3rkJbS1QG8v0nkFdvBJsVOHaywiozhn3+RcehCaaHSUz
-      EZx00UZDQ29osgXuX02XXhyPNyACJ0ptM5D45hdOLrKRA7BP9yaboSghKvc41QN8
-      am8W8YYAPQovhBE1gU7X66oKkF5YcQ9kmbloaeKXMWidaqabOYWWkJajbGnvhrme
-      aJaamb0ga1uDdGqwbbsSErPndc0ysfarqOgWM28IQ6mSNJanbGKQHKIg9W0baqSf
-      aaocaqeagdd4kHLsL7RZdPU2xuX3/5BVbEYBV0B5oSk7xcUWRXbtfLXNP9ILaP4D
-      Ol6wLTLdg9YsIYVJX31amxkSGHtsqCmpui4NOamuh4xKe0M3SFXUqpy4LbueAInb
-      GnfST7+hcxq0nHMG3MHTnVOILc1L5H2PzYN/x/zcuB/2CVpim54pRhueu760F0r8
-      knEfl5e8Z2jSF0yQMQWBOiDwlUBczZYl7UpRnA3LEJqNaWilUh7P7FBalUfQLW4r
-      pnANAEJyzsIfT6wHGeNzfbiqwoM8BiISAdRzdiwdOv95gq22xWGGOqLJaGqmCsbf
-      gbIN3wHSaUxZhcjiUcO1TJVT/o65uq==
-      -----END CERTIFICATE-----
-    EOF
-  end
+  let(:valid_cert) { create(:certificate).to_pem }
+  let(:invalid_cert) { pem_jumble(valid_cert) }
 end

--- a/spec/models/entity_source_spec.rb
+++ b/spec/models/entity_source_spec.rb
@@ -40,54 +40,6 @@ RSpec.describe EntitySource do
   end
 
   context 'certificate validation' do
-    let(:valid_cert) do
-      <<-EOF.gsub(/^\s+/, '')
-        -----BEGIN CERTIFICATE-----
-        MIIDEjCCAfqgAwIBAwIGAUt1eu5UMA0GCSqGSIb3DQEBCwUAMDMxMTAvBgNVBAMM
-        KEZvLUhoc1RzaHZNOG1HR25uQXRRaEE2NFNuUnNfMDI3NElFRjdkYnIwHhcNMTUw
-        MjEwMjE1MjQ1WhcNMTUwMjEwMjIwMjQ1WjAzMTEwLwYDVQQDDChGby1IaHNUc2h2
-        TThtR0dubkF0UWhBNjRTblJzXzAyNzRJRUY3ZGJyMIIBIjANBgkqhkiG9w0BAQEF
-        AAOCAQ8AMIIBCgKCAQEA0pyyFLVsbKJpr1MAS5ofZPz1R+uvbq1ySvBPlMRZNsOO
-        LxW/YE690xPFcUA47KYZdjHhgUx2lyzPRzARn6gRIR+QY2ujC1g+eEUFth4JSi0/
-        KhHoKLm20XYy1k3G11XA8Nh8/IBvZxHIPHl/8UAgr++nGH+6rnWRAEXrha02WXJO
-        Tyus6+x6311O8Yw5bP7L3RKjBs1qg8V0NKfDVbjSvohAYWIOZHN3+rCEHcAAhsuZ
-        ezX00uzdq29OSGxUx02xxHYpnYacj0PTm5d45HDolRkra7bp9YABOsGHkVC41qn8
-        AM8w8yyapqOVHbe1Gu7x66OkKf5yCq9KMBLOAEkxmwIDAQABoywwKjAJBgNVHRME
-        AjAAMB0GA1UdDgQWBBSseRpNDC0YSFARQoGwm28iq6MsnjANBgkqhkiG9w0BAQsF
-        AAOCAQEAGDD4KhlSl7rzDpu2XUx3/5bvBeybv0b5OsK7XCuwrxBTFlxnp9ilAp4d
-        oL6WltlDG9ySiyvjx31AMXKsghTSQcMPUI4noAMUH4XkE0m3sfxuQPY4lBUEaiNB
-        gNFst7+HCXQ0Nhmg3mhtNvoilC1l5h2pZyn/X/ZCUb/2cvPIM54PrHUEU760f0R8
-        KNeFL5E8z2Jsf0YqmqwboIdWLubCZzyL7uPrNa3lejQnAwILuH7p7fbALuFqlw4R
-        PNanaejYZSiFt6WhgEnZFBIQWOm8bIisaDrZDIWDoV95GQ22XwggoQljAgQMcSBF
-        GBin3WhsAuXzHCJIuCo1tjvt/O65UQ==
-        -----END CERTIFICATE-----
-      EOF
-    end
-
-    let(:invalid_cert) do
-      <<-EOF.gsub(/^\s+/, '')
-        -----BEGIN CERTIFICATE-----
-        MIIDEjCCAFQGaWibaWigauT1EU5uma0gcsQgsiB3dqebcWuamdmXmtaVbGnvbamm
-        kezVluHOC1rZAhznog1hr25UqxrrAee2nfnUuNnFmdi3neLfrJDKyNiWhHCnmtuW
-        mJeWmJe1mJq1wHCnmtuWmJeWmJiWmJq1wJaZmteWlWydvqqddcHgBY1iAhnuC2H2
-        ttHTr0DUBKf0uwHbnJrtBLjZxZaYnZrjruy3zgjYmiibiJanbGKQHKIg9W0baqef
-        aaocaq8amiibcGkcaqea0PYYflvSBkjPR1mas5OFzpZ1r+UVBQ1YsVbpLmrznSoo
-        lXw/ye690XpfCua47kyzDJhHGuX2LYZprZarN6Grir+qy2UJc1G+EeufTH4jsI0/
-        kHhOklM20xyY1K3g11xa8nH8/ibVzXhiphL/8uaGR++Ngh+6RNwraexRHA02wxjo
-        tYUS6+X6311o8yW5Bp7l3rkJbS1QG8v0nkFdvBJsVOHaywiozhn3+RcehCaaHSUz
-        EZx00UZDQ29osgXuX02XXhyPNyACJ0ptM5D45hdOLrKRA7BP9yaboSghKvc41QN8
-        am8W8YYAPQovhBE1gU7X66oKkF5YcQ9kmbloaeKXMWidaqabOYWWkJajbGnvhrme
-        aJaamb0ga1uDdGqwbbsSErPndc0ysfarqOgWM28IQ6mSNJanbGKQHKIg9W0baqSf
-        aaocaqeagdd4kHLsL7RZdPU2xuX3/5BVbEYBV0B5oSk7xcUWRXbtfLXNP9ILaP4D
-        Ol6wLTLdg9YsIYVJX31amxkSGHtsqCmpui4NOamuh4xKe0M3SFXUqpy4LbueAInb
-        GnfST7+hcxq0nHMG3MHTnVOILc1L5H2PzYN/x/zcuB/2CVpim54pRhueu760F0r8
-        knEfl5e8Z2jSF0yQMQWBOiDwlUBczZYl7UpRnA3LEJqNaWilUh7P7FBalUfQLW4r
-        pnANAEJyzsIfT6wHGeNzfbiqwoM8BiISAdRzdiwdOv95gq22xWGGOqLJaGqmCsbf
-        gbIN3wHSaUxZhcjiUcO1TJVT/o65uq==
-        -----END CERTIFICATE-----
-      EOF
-    end
-
     it 'accepts a nil certificate' do
       subject.certificate = nil
       expect(subject).to be_valid
@@ -107,5 +59,65 @@ RSpec.describe EntitySource do
       subject.certificate = 'hello!'
       expect(subject).not_to be_valid
     end
+  end
+
+  context '#x509_certificate' do
+    it 'returns nil when certificate is nil' do
+      subject.certificate = nil
+      expect(subject.x509_certificate).to be_nil
+    end
+
+    it 'returns a certificate object' do
+      subject.certificate = valid_cert
+      expect(subject.x509_certificate).to be_an(OpenSSL::X509::Certificate)
+    end
+  end
+
+  let(:valid_cert) do
+    <<-EOF.gsub(/^\s+/, '')
+      -----BEGIN CERTIFICATE-----
+      MIIDEjCCAfqgAwIBAwIGAUt1eu5UMA0GCSqGSIb3DQEBCwUAMDMxMTAvBgNVBAMM
+      KEZvLUhoc1RzaHZNOG1HR25uQXRRaEE2NFNuUnNfMDI3NElFRjdkYnIwHhcNMTUw
+      MjEwMjE1MjQ1WhcNMTUwMjEwMjIwMjQ1WjAzMTEwLwYDVQQDDChGby1IaHNUc2h2
+      TThtR0dubkF0UWhBNjRTblJzXzAyNzRJRUY3ZGJyMIIBIjANBgkqhkiG9w0BAQEF
+      AAOCAQ8AMIIBCgKCAQEA0pyyFLVsbKJpr1MAS5ofZPz1R+uvbq1ySvBPlMRZNsOO
+      LxW/YE690xPFcUA47KYZdjHhgUx2lyzPRzARn6gRIR+QY2ujC1g+eEUFth4JSi0/
+      KhHoKLm20XYy1k3G11XA8Nh8/IBvZxHIPHl/8UAgr++nGH+6rnWRAEXrha02WXJO
+      Tyus6+x6311O8Yw5bP7L3RKjBs1qg8V0NKfDVbjSvohAYWIOZHN3+rCEHcAAhsuZ
+      ezX00uzdq29OSGxUx02xxHYpnYacj0PTm5d45HDolRkra7bp9YABOsGHkVC41qn8
+      AM8w8yyapqOVHbe1Gu7x66OkKf5yCq9KMBLOAEkxmwIDAQABoywwKjAJBgNVHRME
+      AjAAMB0GA1UdDgQWBBSseRpNDC0YSFARQoGwm28iq6MsnjANBgkqhkiG9w0BAQsF
+      AAOCAQEAGDD4KhlSl7rzDpu2XUx3/5bvBeybv0b5OsK7XCuwrxBTFlxnp9ilAp4d
+      oL6WltlDG9ySiyvjx31AMXKsghTSQcMPUI4noAMUH4XkE0m3sfxuQPY4lBUEaiNB
+      gNFst7+HCXQ0Nhmg3mhtNvoilC1l5h2pZyn/X/ZCUb/2cvPIM54PrHUEU760f0R8
+      KNeFL5E8z2Jsf0YqmqwboIdWLubCZzyL7uPrNa3lejQnAwILuH7p7fbALuFqlw4R
+      PNanaejYZSiFt6WhgEnZFBIQWOm8bIisaDrZDIWDoV95GQ22XwggoQljAgQMcSBF
+      GBin3WhsAuXzHCJIuCo1tjvt/O65UQ==
+      -----END CERTIFICATE-----
+    EOF
+  end
+
+  let(:invalid_cert) do
+    <<-EOF.gsub(/^\s+/, '')
+      -----BEGIN CERTIFICATE-----
+      MIIDEjCCAFQGaWibaWigauT1EU5uma0gcsQgsiB3dqebcWuamdmXmtaVbGnvbamm
+      kezVluHOC1rZAhznog1hr25UqxrrAee2nfnUuNnFmdi3neLfrJDKyNiWhHCnmtuW
+      mJeWmJe1mJq1wHCnmtuWmJeWmJiWmJq1wJaZmteWlWydvqqddcHgBY1iAhnuC2H2
+      ttHTr0DUBKf0uwHbnJrtBLjZxZaYnZrjruy3zgjYmiibiJanbGKQHKIg9W0baqef
+      aaocaq8amiibcGkcaqea0PYYflvSBkjPR1mas5OFzpZ1r+UVBQ1YsVbpLmrznSoo
+      lXw/ye690XpfCua47kyzDJhHGuX2LYZprZarN6Grir+qy2UJc1G+EeufTH4jsI0/
+      kHhOklM20xyY1K3g11xa8nH8/ibVzXhiphL/8uaGR++Ngh+6RNwraexRHA02wxjo
+      tYUS6+X6311o8yW5Bp7l3rkJbS1QG8v0nkFdvBJsVOHaywiozhn3+RcehCaaHSUz
+      EZx00UZDQ29osgXuX02XXhyPNyACJ0ptM5D45hdOLrKRA7BP9yaboSghKvc41QN8
+      am8W8YYAPQovhBE1gU7X66oKkF5YcQ9kmbloaeKXMWidaqabOYWWkJajbGnvhrme
+      aJaamb0ga1uDdGqwbbsSErPndc0ysfarqOgWM28IQ6mSNJanbGKQHKIg9W0baqSf
+      aaocaqeagdd4kHLsL7RZdPU2xuX3/5BVbEYBV0B5oSk7xcUWRXbtfLXNP9ILaP4D
+      Ol6wLTLdg9YsIYVJX31amxkSGHtsqCmpui4NOamuh4xKe0M3SFXUqpy4LbueAInb
+      GnfST7+hcxq0nHMG3MHTnVOILc1L5H2PzYN/x/zcuB/2CVpim54pRhueu760F0r8
+      knEfl5e8Z2jSF0yQMQWBOiDwlUBczZYl7UpRnA3LEJqNaWilUh7P7FBalUfQLW4r
+      pnANAEJyzsIfT6wHGeNzfbiqwoM8BiISAdRzdiwdOv95gq22xWGGOqLJaGqmCsbf
+      gbIN3wHSaUxZhcjiUcO1TJVT/o65uq==
+      -----END CERTIFICATE-----
+    EOF
   end
 end

--- a/spec/models/keypair_spec.rb
+++ b/spec/models/keypair_spec.rb
@@ -1,0 +1,44 @@
+require 'rails_helper'
+
+RSpec.describe Keypair do
+  def pem_jumble(pem)
+    parts = pem.split("\n").map do |s|
+      next s if s.start_with?('-----') || s.start_with?('MII')
+      s.reverse
+    end
+
+    parts.join("\n")
+  end
+
+  let(:key) { create(:rsa_key) }
+  let(:certificate) { create(:certificate, rsa_key: key) }
+  let(:other_key) { OpenSSL::PKey::RSA.new(2048) }
+  let(:mismatched_certificate) { create(:certificate, rsa_key: other_key) }
+  let(:invalid_cert) { pem_jumble(certificate.to_pem) }
+  let(:invalid_key) { pem_jumble(key.to_pem) }
+
+  subject { build(:keypair, key: key.to_pem, certificate: certificate.to_pem) }
+
+  context 'validations' do
+    it { is_expected.to be_valid }
+    it { is_expected.to validate_presence(:key) }
+    it { is_expected.to validate_max_length(4096, :key) }
+    it { is_expected.to validate_presence(:certificate) }
+    it { is_expected.to validate_max_length(4096, :certificate) }
+
+    it 'rejects an invalid certificate' do
+      subject.certificate = invalid_cert
+      expect(subject).not_to be_valid
+    end
+
+    it 'rejects an invalid key' do
+      subject.key = invalid_key
+      expect(subject).not_to be_valid
+    end
+
+    it 'rejects a mismatched keypair' do
+      subject.certificate = mismatched_certificate
+      expect(subject).not_to be_valid
+    end
+  end
+end

--- a/spec/models/metadata_instance_spec.rb
+++ b/spec/models/metadata_instance_spec.rb
@@ -5,6 +5,8 @@ describe MetadataInstance do
 
   it { is_expected.to have_one_to_many :entity_descriptors }
   it { is_expected.to have_one_to_many :ca_key_infos }
+  it { is_expected.to have_many_to_one :keypair }
+  it { is_expected.to validate_presence :keypair }
   it { is_expected.to validate_presence :name }
   it { is_expected.not_to validate_presence :publication_info }
   it { is_expected.to validate_presence :hash_algorithm }

--- a/spec/models/metadata_instance_spec.rb
+++ b/spec/models/metadata_instance_spec.rb
@@ -7,6 +7,8 @@ describe MetadataInstance do
   it { is_expected.to have_one_to_many :ca_key_infos }
   it { is_expected.to validate_presence :name }
   it { is_expected.not_to validate_presence :publication_info }
+  it { is_expected.to validate_presence :hash_algorithm }
+  it { is_expected.to validate_includes(%w(sha1 sha256), :hash_algorithm) }
 
   context 'optional attributes' do
     it { is_expected.to have_one_to_one :registration_info }

--- a/spec/support/metadata/signature.rb
+++ b/spec/support/metadata/signature.rb
@@ -59,22 +59,22 @@ RSpec.shared_examples 'ds:Signature xml' do
       .and have_xpath('ds:RSAKeyValue/ds:Exponent', count: 1)
   end
 
-  def bn_base64(bn)
-    Base64.strict_encode64([bn.to_s(16)].pack('H*'))
+  def base64_to_i(str)
+    Base64.decode64(str).unpack('C*').reduce { |a, e| (a << 8) + e }
   end
 
   it 'includes the key modulus' do
-    modulus = key_value.find(:xpath, './/ds:Modulus').text
+    modulus = base64_to_i(key_value.find(:xpath, './/ds:Modulus').text)
     key = certificate.public_key
 
-    expect(modulus).to eq(bn_base64(key.n))
+    expect(modulus).to eq(key.n.to_i)
   end
 
   it 'includes the key exponent' do
-    exponent = key_value.find(:xpath, './/ds:Exponent').text
+    exponent = base64_to_i(key_value.find(:xpath, './/ds:Exponent').text)
     key = certificate.public_key
 
-    expect(exponent).to eq(bn_base64(key.e))
+    expect(exponent).to eq(key.e.to_i)
   end
 
   it 'includes the X509 certificate' do

--- a/spec/support/metadata/signature.rb
+++ b/spec/support/metadata/signature.rb
@@ -5,6 +5,12 @@ RSpec.shared_examples 'ds:Signature xml' do
   let(:reference) { signed_info.find(:xpath, 'ds:Reference') }
   let(:key_value) { signature.find(:xpath, 'ds:KeyInfo/ds:KeyValue') }
 
+  let(:key) { OpenSSL::PKey::RSA.new(metadata_instance.keypair.key) }
+
+  let(:certificate) do
+    OpenSSL::X509::Certificate.new(metadata_instance.keypair.certificate)
+  end
+
   it 'has a <Signature> element' do
     expect(xml).to have_xpath("#{sig_xpath}")
   end
@@ -90,7 +96,7 @@ RSpec.shared_examples 'ds:Signature xml' do
   context 'with a signed document' do
     let(:schema) { Nokogiri::XML::Schema.new(File.open('schema/top.xsd', 'r')) }
     let(:validation_errors) { schema.validate(Nokogiri::XML.parse(raw_xml)) }
-    let(:raw_xml) { subject.sign(key) }
+    let(:raw_xml) { subject.sign }
 
     let(:c14n_xml) do
       doc = subject.builder.doc.dup

--- a/spec/support/metadata/signature.rb
+++ b/spec/support/metadata/signature.rb
@@ -1,0 +1,99 @@
+RSpec.shared_examples 'ds:Signature xml' do
+  let(:sig_xpath) { '/*[local-name() = "EntitiesDescriptor"]/ds:Signature' }
+  let(:signature) { xml.find(:xpath, sig_xpath) }
+  let(:signed_info) { xml.find(:xpath, "#{sig_xpath}/ds:SignedInfo") }
+  let(:reference) { signed_info.find(:xpath, 'ds:Reference') }
+  let(:key_value) { signature.find(:xpath, 'ds:KeyInfo/ds:KeyValue') }
+
+  it 'has a <Signature> element' do
+    expect(xml).to have_xpath("#{sig_xpath}")
+  end
+
+  it 'specifies the c14n method' do
+    expect(signed_info).to have_xpath('ds:CanonicalizationMethod', count: 1)
+  end
+
+  it 'uses the correct c14n method' do
+    e = signed_info.find(:xpath, 'ds:CanonicalizationMethod')
+    expect(e['Algorithm']).to eq('http://www.w3.org/2001/10/xml-exc-c14n#')
+  end
+
+  it 'specifies the signature method' do
+    expect(signed_info).to have_xpath('ds:SignatureMethod', count: 1)
+  end
+
+  it 'uses the correct signature method' do
+    e = signed_info.find(:xpath, 'ds:SignatureMethod')
+    expect(e['Algorithm']).to eq('http://www.w3.org/2000/09/xmldsig#rsa-sha1')
+  end
+
+  it 'includes the reference element' do
+    expect(signed_info).to have_xpath('ds:Reference', count: 1)
+  end
+
+  it 'designates the root element to be signed' do
+    expect(reference['URI']).to eq("##{subject.instance_id}")
+  end
+
+  it 'includes the transforms' do
+    expect(reference).to have_xpath('ds:Transforms', count: 1)
+    expect(reference).to have_xpath('ds:Transforms/ds:Transform', count: 2)
+  end
+
+  it 'specifies the transform algorithms' do
+    transforms = reference.all(:xpath, 'ds:Transforms/ds:Transform')
+                 .map { |transform| transform['Algorithm'] }
+    expect(transforms).to contain_exactly(
+      'http://www.w3.org/2000/09/xmldsig#enveloped-signature',
+      'http://www.w3.org/2001/10/xml-exc-c14n#'
+    )
+  end
+
+  it 'includes the digest method' do
+    expect(reference).to have_xpath('ds:DigestMethod', count: 1)
+  end
+
+  it 'specifies the digest algorithm' do
+    e = reference.find(:xpath, 'ds:DigestMethod')
+    expect(e['Algorithm']).to eq('http://www.w3.org/2000/09/xmldsig#sha1')
+  end
+
+  it 'includes the key info' do
+    expect(signature).to have_xpath('ds:KeyInfo', count: 1)
+      .and have_xpath('ds:KeyInfo/ds:KeyValue', count: 1)
+
+    expect(key_value).to have_xpath('ds:RSAKeyValue', count: 1)
+      .and have_xpath('ds:RSAKeyValue/ds:Modulus', count: 1)
+      .and have_xpath('ds:RSAKeyValue/ds:Exponent', count: 1)
+      .and have_xpath('ds:X509Data', count: 1)
+      .and have_xpath('ds:X509Data/ds:X509Certificate', count: 1)
+  end
+
+  def bn_base64(bn)
+    Base64.strict_encode64([bn.to_s(16)].pack('H*'))
+  end
+
+  it 'includes the key modulus' do
+    modulus = key_value.find(:xpath, './/ds:Modulus').text
+    key = certificate.public_key
+
+    expect(modulus).to eq(bn_base64(key.n))
+  end
+
+  it 'includes the key exponent' do
+    exponent = key_value.find(:xpath, './/ds:Exponent').text
+    key = certificate.public_key
+
+    expect(exponent).to eq(bn_base64(key.e))
+  end
+
+  it 'includes the X509 certificate' do
+    cert = [
+      '-----BEGIN CERTIFICATE-----',
+      key_value.find(:xpath, './/ds:X509Certificate').text.strip,
+      '-----END CERTIFICATE-----'
+    ].join("\n")
+
+    expect(cert).to eq(certificate.to_pem.strip)
+  end
+end


### PR DESCRIPTION
~~Implemented using SHA1 digest / signature because that's what we currently use. SHA256 is not defined by [the specification](http://www.w3.org/TR/xmldsig-core/#sec-Algorithms) as one of the available options, and some rudimentary testing showed that support in the `xmldsig` library isn't quite there.~~

~~It wouldn't be hard to implement if/when we need it though. The test cases are a near-complete implementation of the spec anyway.~~

The test cases verify that the generated content matches what we currently have in production.