### PR TITLE
Feature/metadata query protocol

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ rerun.txt
 
 config/initializers/secret_token.rb
 config/secrets.yml
+config/saml_service.yml
 
 ## Environment normalisation:
 /.bundle

--- a/Gemfile
+++ b/Gemfile
@@ -14,6 +14,8 @@ gem 'resque'
 gem 'resque-retry'
 gem 'redis'
 
+gem 'recursive-open-struct'
+
 # Web
 gem 'uglifier', '>= 1.3.0'
 gem 'therubyracer',  platforms: :ruby

--- a/Gemfile
+++ b/Gemfile
@@ -46,6 +46,7 @@ group :development, :test do
   gem 'guard-rspec', require: false
   gem 'guard-brakeman', require: false
   gem 'pry-rails'
+  gem 'pry-byebug'
   gem 'capybara', '~> 2.4.4'
   gem 'timecop', '~>0.7.1'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -222,6 +222,7 @@ GEM
     rb-fsevent (0.9.4)
     rb-inotify (0.9.5)
       ffi (>= 0.5.0)
+    recursive-open-struct (0.6.5)
     redis (3.2.0)
     redis-namespace (1.5.1)
       redis (~> 3.0, >= 3.0.4)
@@ -369,6 +370,7 @@ DEPENDENCIES
   pry-byebug
   pry-rails
   rails (= 4.2.0)
+  recursive-open-struct
   redis
   resque
   resque-retry

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -70,6 +70,8 @@ GEM
       slim (>= 1.3.6, < 3.0)
       terminal-table (~> 1.4)
     builder (3.2.2)
+    byebug (4.0.5)
+      columnize (= 0.9.0)
     capybara (2.4.4)
       mime-types (>= 1.16)
       nokogiri (>= 1.3.3)
@@ -86,6 +88,7 @@ GEM
       coffee-script-source
       execjs
     coffee-script-source (1.8.0)
+    columnize (0.9.0)
     coveralls (0.7.1)
       multi_json (~> 1.3)
       rest-client
@@ -179,6 +182,9 @@ GEM
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
       slop (~> 3.4)
+    pry-byebug (3.1.0)
+      byebug (~> 4.0)
+      pry (~> 0.10)
     pry-rails (0.3.2)
       pry (>= 0.9.10)
     rack (1.6.0)
@@ -360,6 +366,7 @@ DEPENDENCIES
   jbuilder
   mysql2
   nokogiri (~> 1.6.5)
+  pry-byebug
   pry-rails
   rails (= 4.2.0)
   redis

--- a/app/controllers/concerns/metadata_query_caching.rb
+++ b/app/controllers/concerns/metadata_query_caching.rb
@@ -18,8 +18,8 @@ module MetadataQueryCaching
     false
   end
 
-  def descriptor_unmodified(descriptor, etag)
-    return true if valid_etag(etag) || unmodified(descriptor)
+  def known_entity_unmodified(known_entity, etag)
+    return true if valid_etag(etag) || unmodified(known_entity)
     false
   end
 
@@ -33,12 +33,12 @@ module MetadataQueryCaching
     obj.updated_at <= request.headers['If-Modified-Since']
   end
 
-  def cache_descriptor_response(descriptor, etag)
+  def cache_descriptor_response(known_entity, etag)
     cache_expiry_period = @metadata_instance.validity_period
     cache_expiry = Time.now + cache_expiry_period
 
     Rails.cache.fetch(etag, expires_in: cache_expiry_period) do
-      @saml_renderer.root_entity_descriptor(descriptor)
+      @saml_renderer.root_entity_descriptor(known_entity)
       @saml_renderer.sign
 
       { expires: cache_expiry, metadata: @saml_renderer.builder.to_xml }

--- a/app/controllers/concerns/metadata_query_caching.rb
+++ b/app/controllers/concerns/metadata_query_caching.rb
@@ -11,16 +11,11 @@ module MetadataQueryCaching
   end
 
   def known_entities_unmodified(known_entities, etag)
-    if valid_etag(etag) || unmodified(known_entities.sort_by(&:updated_at).last)
-      return true
-    end
-
-    false
+    valid_etag(etag) || unmodified(known_entities.sort_by(&:updated_at).last)
   end
 
   def known_entity_unmodified(known_entity, etag)
-    return true if valid_etag(etag) || unmodified(known_entity)
-    false
+    valid_etag(etag) || unmodified(known_entity)
   end
 
   def valid_etag(etag)

--- a/app/controllers/concerns/metadata_query_caching.rb
+++ b/app/controllers/concerns/metadata_query_caching.rb
@@ -10,20 +10,20 @@ module MetadataQueryCaching
     Digest::MD5.hexdigest("samlmetadata/#{desc.id}-#{desc.updated_at}")
   end
 
-  def known_entities_unmodified(known_entities, etag)
-    valid_etag(etag) || unmodified(known_entities.sort_by(&:updated_at).last)
+  def known_entities_unmodified?(known_entities, etag)
+    valid_etag?(etag) || unmodified?(known_entities.sort_by(&:updated_at).last)
   end
 
-  def known_entity_unmodified(known_entity, etag)
-    valid_etag(etag) || unmodified(known_entity)
+  def known_entity_unmodified?(known_entity, etag)
+    valid_etag?(etag) || unmodified?(known_entity)
   end
 
-  def valid_etag(etag)
+  def valid_etag?(etag)
     return false unless request.headers['If-None-Match']
     request.headers['If-None-Match'] == etag
   end
 
-  def unmodified(obj)
+  def unmodified?(obj)
     return false unless request.headers['If-Modified-Since']
     obj.updated_at <= request.headers['If-Modified-Since']
   end

--- a/app/controllers/concerns/metadata_query_caching.rb
+++ b/app/controllers/concerns/metadata_query_caching.rb
@@ -1,0 +1,59 @@
+module MetadataQueryCaching
+  extend ActiveSupport::Concern
+
+  def generate_known_entities_etag(known_entities)
+    timestamps = known_entities.map(&:updated_at).map(&:to_i).join('.')
+    Digest::MD5.hexdigest("samlmetadata/#{timestamps}")
+  end
+
+  def generate_descriptor_etag(desc)
+    Digest::MD5.hexdigest("samlmetadata/#{desc.id}-#{desc.updated_at}")
+  end
+
+  def known_entities_unmodified(known_entities, etag)
+    if valid_etag(etag) || unmodified(known_entities.sort_by(&:updated_at).last)
+      return true
+    end
+
+    false
+  end
+
+  def descriptor_unmodified(descriptor, etag)
+    return true if valid_etag(etag) || unmodified(descriptor)
+    false
+  end
+
+  def valid_etag(etag)
+    return false unless request.headers['If-None-Match']
+    request.headers['If-None-Match'] == etag
+  end
+
+  def unmodified(obj)
+    return false unless request.headers['If-Modified-Since']
+    obj.updated_at <= request.headers['If-Modified-Since']
+  end
+
+  def cache_descriptor_response(descriptor, etag)
+    cache_expiry_period = @metadata_instance.validity_period
+    cache_expiry = Time.now + cache_expiry_period
+
+    Rails.cache.fetch(etag, expires_in: cache_expiry_period) do
+      @saml_renderer.root_entity_descriptor(descriptor)
+      @saml_renderer.sign
+
+      { expires: cache_expiry, metadata: @saml_renderer.builder.to_xml }
+    end
+  end
+
+  def cache_known_entities_response(known_entities, etag)
+    cache_expiry_period = @metadata_instance.validity_period
+    cache_expiry = Time.now + cache_expiry_period
+
+    Rails.cache.fetch(etag, expires_in: cache_expiry_period) do
+      @saml_renderer.entities_descriptor(known_entities)
+      @saml_renderer.sign
+
+      { expires: cache_expiry, metadata: @saml_renderer.builder.to_xml }
+    end
+  end
+end

--- a/app/controllers/metadata_query_controller.rb
+++ b/app/controllers/metadata_query_controller.rb
@@ -94,7 +94,7 @@ class MetadataQueryController < ApplicationController
 
   def ensure_metadata_instance
     @metadata_instance =
-      MetadataInstance.where[primary_tag: params[:primary_tag]]
+      MetadataInstance[primary_tag: params[:primary_tag]]
     if @metadata_instance
       @saml_renderer = Metadata::SAML.new(metadata_instance: @metadata_instance)
       return

--- a/app/controllers/metadata_query_controller.rb
+++ b/app/controllers/metadata_query_controller.rb
@@ -38,14 +38,14 @@ class MetadataQueryController < ApplicationController
   def specific_entity
     public_action
 
-    entity_descriptor = EntityId.first(uri: params[:identifier])
-                        .try(:entity_descriptor)
-    return head :not_found unless entity_descriptor
+    known_entity = EntityId.first(uri: params[:identifier])
+                   .try(:entity_descriptor).try(:known_entity)
+    return head :not_found unless known_entity
 
-    etag = generate_descriptor_etag(entity_descriptor)
-    return head :not_modified if descriptor_unmodified(entity_descriptor, etag)
+    etag = generate_descriptor_etag(known_entity)
+    return head :not_modified if known_entity_unmodified(known_entity, etag)
 
-    create_descriptor_response(entity_descriptor, etag)
+    create_known_entity_response(known_entity, etag)
   end
 
   private
@@ -93,10 +93,10 @@ class MetadataQueryController < ApplicationController
     expires_in ttl
   end
 
-  def create_descriptor_response(descriptor, etag)
-    response = cache_descriptor_response(descriptor, etag)
+  def create_known_entity_response(known_entity, etag)
+    response = cache_descriptor_response(known_entity, etag)
 
-    create_headers(descriptor, etag, response[:expires])
+    create_headers(known_entity, etag, response[:expires])
     render body: response[:metadata]
   end
 

--- a/app/controllers/metadata_query_controller.rb
+++ b/app/controllers/metadata_query_controller.rb
@@ -18,7 +18,9 @@ class MetadataQueryController < ApplicationController
     return head :not_found unless known_entities.present?
 
     etag = generate_known_entities_etag(known_entities)
-    return head :not_modified if known_entities_unmodified(known_entities, etag)
+    if known_entities_unmodified?(known_entities, etag)
+      return head :not_modified
+    end
 
     create_known_entities_response(known_entities, etag)
   end
@@ -31,7 +33,9 @@ class MetadataQueryController < ApplicationController
     return head :not_found unless known_entities.present?
 
     etag = generate_known_entities_etag(known_entities)
-    return head :not_modified if known_entities_unmodified(known_entities, etag)
+    if known_entities_unmodified?(known_entities, etag)
+      return head :not_modified
+    end
 
     create_known_entities_response(known_entities, etag)
   end
@@ -44,7 +48,7 @@ class MetadataQueryController < ApplicationController
     return head :not_found unless known_entity
 
     etag = generate_descriptor_etag(known_entity)
-    return head :not_modified if known_entity_unmodified(known_entity, etag)
+    return head :not_modified if known_entity_unmodified?(known_entity, etag)
 
     create_known_entity_response(known_entity, etag)
   end
@@ -60,7 +64,7 @@ class MetadataQueryController < ApplicationController
     return head :not_found unless known_entity
 
     etag = generate_descriptor_etag(known_entity)
-    return head :not_modified if known_entity_unmodified(known_entity, etag)
+    return head :not_modified if known_entity_unmodified?(known_entity, etag)
 
     create_known_entity_response(known_entity, etag)
   end

--- a/app/controllers/metadata_query_controller.rb
+++ b/app/controllers/metadata_query_controller.rb
@@ -106,7 +106,7 @@ class MetadataQueryController < ApplicationController
 
   def create_headers(obj, etag, expiry)
     response.headers['ETag'] = etag
-    response.headers['Last-Modified'] = obj.updated_at
+    response.headers['Last-Modified'] = obj.updated_at.rfc2822
     response.headers['Content-Type'] =
       "#{MetadataQueryController::SAML_CONTENT_TYPE}; charset=utf-8"
 

--- a/app/controllers/metadata_query_controller.rb
+++ b/app/controllers/metadata_query_controller.rb
@@ -12,23 +12,35 @@ class MetadataQueryController < ApplicationController
 
   def all_entities
     public_action
+
     return not_found unless @metadata_instance.all_entities
-
-    known_entities = KnownEntity.with_all_tags(@metadata_instance.primary_tag)
-    return not_found unless known_entities.present?
-
-    etag = generate_known_entities_etag(known_entities)
-    if known_entities_unmodified?(known_entities, etag)
-      return head :not_modified
-    end
-
-    create_known_entities_response(known_entities, etag)
+    tags = [@metadata_instance.primary_tag]
+    handle_entities_request(tags)
   end
 
   def tagged_entities
     public_action
 
     tags = [@metadata_instance.primary_tag, params[:identifier]]
+    handle_entities_request(tags)
+  end
+
+  def specific_entity
+    public_action
+
+    handle_entity_request(EntityId.first(uri: params[:identifier]))
+  end
+
+  def specific_entity_sha1
+    public_action
+
+    sha1_identifier = params[:identifier].match(SHA1_REGEX)
+    handle_entity_request(EntityId.first(sha1: sha1_identifier[1]))
+  end
+
+  private
+
+  def handle_entities_request(tags)
     known_entities = KnownEntity.with_all_tags(tags)
     return not_found unless known_entities.present?
 
@@ -40,36 +52,15 @@ class MetadataQueryController < ApplicationController
     create_known_entities_response(known_entities, etag)
   end
 
-  def specific_entity
-    public_action
+  def handle_entity_request(entity_id)
+    return not_found unless entity_id
 
-    known_entity = EntityId.first(uri: params[:identifier])
-                   .try(:parent).try(:known_entity)
-    return not_found unless known_entity
-
+    known_entity = entity_id.parent.known_entity
     etag = generate_descriptor_etag(known_entity)
     return head :not_modified if known_entity_unmodified?(known_entity, etag)
 
     create_known_entity_response(known_entity, etag)
   end
-
-  def specific_entity_sha1
-    public_action
-
-    sha1_identifier = params[:identifier].match(SHA1_REGEX)
-    return not_found unless sha1_identifier
-
-    known_entity = EntityId.first(sha1: sha1_identifier[1])
-                   .try(:parent).try(:known_entity)
-    return not_found unless known_entity
-
-    etag = generate_descriptor_etag(known_entity)
-    return head :not_modified if known_entity_unmodified?(known_entity, etag)
-
-    create_known_entity_response(known_entity, etag)
-  end
-
-  private
 
   def ensure_get_request
     return if request.get?

--- a/app/controllers/metadata_query_controller.rb
+++ b/app/controllers/metadata_query_controller.rb
@@ -39,7 +39,7 @@ class MetadataQueryController < ApplicationController
     public_action
 
     known_entity = EntityId.first(uri: params[:identifier])
-                   .try(:entity_descriptor).try(:known_entity)
+                   .try(:parent).try(:known_entity)
     return head :not_found unless known_entity
 
     etag = generate_descriptor_etag(known_entity)

--- a/app/controllers/metadata_query_controller.rb
+++ b/app/controllers/metadata_query_controller.rb
@@ -1,0 +1,110 @@
+require 'metadata/saml'
+
+class MetadataQueryController < ApplicationController
+  SAML_CONTENT_TYPE = 'application/samlmetadata+xml'.freeze
+
+  include MetadataQueryCaching
+
+  skip_before_action :ensure_authenticated
+  before_action :ensure_get_request, :ensure_content_type,
+                :ensure_accept_charset, :ensure_metadata_instance
+
+  def all_entities
+    public_action
+    return head :not_found unless @metadata_instance.all_entities
+
+    known_entities = KnownEntity.with_all_tags(@metadata_instance.primary_tag)
+    return head :not_found unless known_entities.present?
+
+    etag = generate_known_entities_etag(known_entities)
+    return head :not_modified if known_entities_unmodified(known_entities, etag)
+
+    create_known_entities_response(known_entities, etag)
+  end
+
+  def tagged_entities
+    public_action
+
+    tags = [@metadata_instance.primary_tag, params[:identifier]]
+    known_entities = KnownEntity.with_all_tags(tags)
+    return head :not_found unless known_entities.present?
+
+    etag = generate_known_entities_etag(known_entities)
+    return head :not_modified if known_entities_unmodified(known_entities, etag)
+
+    create_known_entities_response(known_entities, etag)
+  end
+
+  def specific_entity
+    public_action
+
+    entity_descriptor = EntityId.first(uri: params[:identifier])
+                        .try(:entity_descriptor)
+    return head :not_found unless entity_descriptor
+
+    etag = generate_descriptor_etag(entity_descriptor)
+    return head :not_modified if descriptor_unmodified(entity_descriptor, etag)
+
+    create_descriptor_response(entity_descriptor, etag)
+  end
+
+  private
+
+  def ensure_get_request
+    return if request.get?
+
+    head :method_not_allowed
+    false
+  end
+
+  def ensure_content_type
+    return if request.accept == MetadataQueryController::SAML_CONTENT_TYPE
+
+    head :not_acceptable
+    false
+  end
+
+  def ensure_accept_charset
+    return if !request.accept_charset || request.accept_charset == 'utf-8'
+
+    head :not_acceptable
+    false
+  end
+
+  def ensure_metadata_instance
+    @metadata_instance =
+      MetadataInstance.where[primary_tag: params[:primary_tag]]
+    if @metadata_instance
+      @saml_renderer = Metadata::SAML.new(metadata_instance: @metadata_instance)
+      return
+    end
+
+    head :not_found
+    false
+  end
+
+  def create_headers(obj, etag, expiry)
+    response.headers['ETag'] = etag
+    response.headers['Last-Modified'] = obj.updated_at
+    response.headers['Content-Type'] =
+      "#{MetadataQueryController::SAML_CONTENT_TYPE}; charset=utf-8"
+
+    ttl = expiry - Time.now
+    expires_in ttl
+  end
+
+  def create_descriptor_response(descriptor, etag)
+    response = cache_descriptor_response(descriptor, etag)
+
+    create_headers(descriptor, etag, response[:expires])
+    render body: response[:metadata]
+  end
+
+  def create_known_entities_response(known_entities, etag)
+    response = cache_known_entities_response(known_entities, etag)
+
+    create_headers(known_entities.sort_by(&:updated_at).last,
+                   etag, response[:expires])
+    render body: response[:metadata]
+  end
+end

--- a/app/jobs/update_entity_source.rb
+++ b/app/jobs/update_entity_source.rb
@@ -60,8 +60,10 @@ class UpdateEntitySource
   end
 
   def known_entity(source, node)
-    attrs = { entity_source: source, entity_id: node['entityID'] }
-    KnownEntity.find_or_create(attrs) { |e| e.active = true }
+    entity_id = EntityId.find(uri: node['entityID'])
+    return entity_id.parent.known_entity if entity_id
+
+    KnownEntity.create(entity_source: source, active: true)
   end
 
   def update_raw_entity_descriptor(entity, node)

--- a/app/models/entity_descriptor.rb
+++ b/app/models/entity_descriptor.rb
@@ -40,19 +40,6 @@ class EntityDescriptor < Sequel::Model
     entity_attribute.try(:present?)
   end
 
-  def self.with_any_tag(tags)
-    join_tags(tags).all
-  end
-
-  def self.with_all_tags(tags)
-    join_tags(tags).having { "count(*) = #{[tags].flatten.length}" }.all
-  end
-
-  def self.join_tags(tags)
-    qualify.join(:tags, entity_descriptor_id: :id, name: tags)
-      .group(:entity_descriptor_id)
-  end
-
   protected
 
   def technical_contact_count

--- a/app/models/entity_id.rb
+++ b/app/models/entity_id.rb
@@ -1,12 +1,18 @@
 require 'digest/sha1'
 
 class EntityId < SamlURI
+  include Parents
+
   many_to_one :entity_descriptor
+  many_to_one :raw_entity_descriptor
 
   def validate
     super
-    validates_presence [:entity_descriptor, :sha1]
+    validates_presence :sha1
     validates_max_length 1024, :uri
+    return if new?
+
+    single_parent [:entity_descriptor, :raw_entity_descriptor]
   end
 
   def before_validation

--- a/app/models/entity_id.rb
+++ b/app/models/entity_id.rb
@@ -21,7 +21,6 @@ class EntityId < SamlURI
   end
 
   def parent
-    return entity_descriptor if entity_descriptor
-    raw_entity_descriptor
+    entity_descriptor || raw_entity_descriptor
   end
 end

--- a/app/models/entity_id.rb
+++ b/app/models/entity_id.rb
@@ -19,4 +19,9 @@ class EntityId < SamlURI
     super
     self.sha1 = Digest::SHA1.hexdigest uri if uri
   end
+
+  def parent
+    return entity_descriptor if entity_descriptor
+    raw_entity_descriptor
+  end
 end

--- a/app/models/entity_id.rb
+++ b/app/models/entity_id.rb
@@ -1,9 +1,16 @@
+require 'digest/sha1'
+
 class EntityId < SamlURI
   many_to_one :entity_descriptor
 
   def validate
     super
-    validates_presence :entity_descriptor
+    validates_presence [:entity_descriptor, :sha1]
     validates_max_length 1024, :uri
+  end
+
+  def before_validation
+    super
+    self.sha1 = Digest::SHA1.hexdigest uri if uri
   end
 end

--- a/app/models/known_entity.rb
+++ b/app/models/known_entity.rb
@@ -3,10 +3,25 @@ class KnownEntity < Sequel::Model
   one_to_one :entity_descriptor
   one_to_one :raw_entity_descriptor
 
+  one_to_many :tags
+
   alias_method :active?, :active
 
   def validate
     super
     validates_presence [:entity_source, :active, :created_at, :updated_at]
+  end
+
+  def self.with_any_tag(tags)
+    join_tags(tags).all
+  end
+
+  def self.with_all_tags(tags)
+    join_tags(tags).having { "count(*) = #{[tags].flatten.length}" }.all
+  end
+
+  def self.join_tags(tags)
+    qualify.join(:tags, known_entity_id: :id, name: tags)
+      .group(:known_entity_id)
   end
 end

--- a/app/models/known_entity.rb
+++ b/app/models/known_entity.rb
@@ -24,4 +24,11 @@ class KnownEntity < Sequel::Model
     qualify.join(:tags, known_entity_id: :id, name: tags)
       .group(:known_entity_id)
   end
+
+  def entity_id
+    return entity_descriptor.entity_id.uri if entity_descriptor
+    return raw_entity_descriptor.entity_id.uri if raw_entity_descriptor
+
+    nil
+  end
 end

--- a/app/models/metadata_instance.rb
+++ b/app/models/metadata_instance.rb
@@ -14,5 +14,7 @@ class MetadataInstance < Sequel::Model
     validates_presence :publication_info unless new?
 
     validates_includes %w(sha1 sha256), :hash_algorithm
+
+    validates_presence :primary_tag
   end
 end

--- a/app/models/metadata_instance.rb
+++ b/app/models/metadata_instance.rb
@@ -1,7 +1,5 @@
 class MetadataInstance < Sequel::Model
   many_to_one :keypair
-
-  one_to_many :entity_descriptors
   one_to_many :ca_key_infos
 
   one_to_one :registration_info, class: 'MDRPI::RegistrationInfo'

--- a/app/models/metadata_instance.rb
+++ b/app/models/metadata_instance.rb
@@ -16,5 +16,6 @@ class MetadataInstance < Sequel::Model
     validates_includes %w(sha1 sha256), :hash_algorithm
 
     validates_presence :primary_tag
+    validates_presence :all_entities
   end
 end

--- a/app/models/metadata_instance.rb
+++ b/app/models/metadata_instance.rb
@@ -9,13 +9,11 @@ class MetadataInstance < Sequel::Model
   def validate
     super
     validates_presence [:name, :created_at, :updated_at, :hash_algorithm,
-                        :keypair]
+                        :keypair, :federation_identifier, :validity_period,
+                        :primary_tag, :all_entities]
     validates_presence :ca_verify_depth if ca_key_infos.present?
     validates_presence :publication_info unless new?
 
     validates_includes %w(sha1 sha256), :hash_algorithm
-
-    validates_presence :primary_tag
-    validates_presence :all_entities
   end
 end

--- a/app/models/raw_entity_descriptor.rb
+++ b/app/models/raw_entity_descriptor.rb
@@ -5,10 +5,13 @@ class RawEntityDescriptor < Sequel::Model
 
   many_to_one :known_entity
 
+  one_to_one :entity_id
+
   def validate
     super
     validates_presence [:known_entity, :xml, :created_at, :updated_at]
     validates_unique :known_entity
+    validates_presence :entity_id, allow_missing: new?
     # Any more than 65535, the column type needs to be upgraded.
     validates_max_length 65_535, :xml
     validate_xml

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -1,14 +1,14 @@
 class Tag < Sequel::Model
   include Parents
   plugin :validation_helpers
-  many_to_one :entity_descriptor
+  many_to_one :known_entity
   many_to_one :role_descriptor
 
   def validate
     super
-    validates_unique([:name, :entity_descriptor])
+    validates_unique([:name, :known_entity])
     validates_unique([:name, :role_descriptor])
     validates_presence [:name, :created_at, :updated_at]
-    single_parent [:entity_descriptor, :role_descriptor]
+    single_parent [:known_entity, :role_descriptor]
   end
 end

--- a/config/initializers/app_config.rb
+++ b/config/initializers/app_config.rb
@@ -1,0 +1,4 @@
+Rails.application.configure do
+  config.saml_service =
+    RecursiveOpenStruct.new(config_for(:saml_service).deep_symbolize_keys)
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,17 +1,19 @@
 Rails.application.routes.draw do
-  uri_regexp = URI.regexp(%w(http https urn:mace))
-  sha1_regex = /{sha1}(.*)?/
+  URI_REGEXP = URI.regexp(%w(http https urn:mace))
+  SHA1_REGEXP = /{sha1}(.*)?/
 
   match '/:primary_tag/entities',
         to: 'metadata_query#all_entities', via: :all
 
   match '/:primary_tag/entities/:identifier',
         to: 'metadata_query#specific_entity',
-        constraints: { identifier: uri_regexp }, via: :all
+        constraints: { identifier: URI_REGEXP }, via: :all
 
   match '/:primary_tag/entities/:identifier',
         to: 'metadata_query#specific_entity_sha1',
-        constraints: { identifier: sha1_regex }, via: :all
+        constraints: # check regexp against decoded URI params
+          -> (r) { r.path_parameters[:identifier].match(SHA1_REGEXP) },
+        via: :all
 
   match '/:primary_tag/entities/:identifier',
         to: 'metadata_query#tagged_entities', via: :all

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,2 +1,13 @@
 Rails.application.routes.draw do
+  uri_regexp = URI.regexp(%w(http https urn:mace))
+
+  match '/:primary_tag/entities',
+        to: 'metadata_query#all_entities', via: :all
+
+  match '/:primary_tag/entities/:identifier',
+        to: 'metadata_query#specific_entity',
+        constraints: { identifier: uri_regexp }, via: :all
+
+  match '/:primary_tag/entities/:identifier',
+        to: 'metadata_query#tagged_entities', via: :all
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,6 @@
 Rails.application.routes.draw do
   uri_regexp = URI.regexp(%w(http https urn:mace))
+  sha1_regex = /{sha1}(.*)?/
 
   match '/:primary_tag/entities',
         to: 'metadata_query#all_entities', via: :all
@@ -7,6 +8,10 @@ Rails.application.routes.draw do
   match '/:primary_tag/entities/:identifier',
         to: 'metadata_query#specific_entity',
         constraints: { identifier: uri_regexp }, via: :all
+
+  match '/:primary_tag/entities/:identifier',
+        to: 'metadata_query#specific_entity_sha1',
+        constraints: { identifier: sha1_regex }, via: :all
 
   match '/:primary_tag/entities/:identifier',
         to: 'metadata_query#tagged_entities', via: :all

--- a/config/saml_service.yml.dist
+++ b/config/saml_service.yml.dist
@@ -1,0 +1,12 @@
+defaults: &defaults
+  metadata:
+    negative_cache_ttl: 600
+
+development:
+  <<: *defaults
+
+test:
+  <<: *defaults
+
+production:
+  <<: *defaults

--- a/db/migrate/20150504231555_add_primary_tag_to_metadata_instance.rb
+++ b/db/migrate/20150504231555_add_primary_tag_to_metadata_instance.rb
@@ -1,0 +1,7 @@
+Sequel.migration do
+  change do
+    alter_table :metadata_instances do
+      add_column :primary_tag, String, null: false
+    end
+  end
+end

--- a/db/migrate/20150504232739_add_all_entities_to_metadata_instance.rb
+++ b/db/migrate/20150504232739_add_all_entities_to_metadata_instance.rb
@@ -1,0 +1,7 @@
+Sequel.migration do
+  change do
+    alter_table :metadata_instances do
+      add_column :all_entities, TrueClass, null: false, default: true
+    end
+  end
+end

--- a/db/migrate/20150505032956_add_saml_fields_to_metadata_instance.rb
+++ b/db/migrate/20150505032956_add_saml_fields_to_metadata_instance.rb
@@ -1,0 +1,9 @@
+Sequel.migration do
+  change do
+    alter_table :metadata_instances do
+      add_column :federation_identifier, String, null: false
+      add_column :validity_period, Integer, null: false
+      drop_column :identifier
+    end
+  end
+end

--- a/db/migrate/20150505052005_drop_entity_descriptor_from_tags.rb
+++ b/db/migrate/20150505052005_drop_entity_descriptor_from_tags.rb
@@ -1,0 +1,16 @@
+Sequel.migration do
+  up do
+    alter_table :tags do
+      drop_foreign_key :entity_descriptor_id
+      drop_constraint('name_entity_descriptor_id_un', type: :unique)
+    end
+  end
+
+  down do
+    alter_table :tags do
+      add_foreign_key :entity_descriptor_id, :entity_descriptors
+      add_unique_constraint([:name, :entity_descriptor_id],
+                            :name=>'name_entity_descriptor_id_un')
+    end
+  end
+end

--- a/db/migrate/20150505052251_add_known_entity_foreign_key_to_tags.rb
+++ b/db/migrate/20150505052251_add_known_entity_foreign_key_to_tags.rb
@@ -1,0 +1,16 @@
+Sequel.migration do
+  up do
+    alter_table :tags do
+      add_foreign_key :known_entity_id, :known_entities
+      add_unique_constraint([:name, :known_entity_id],
+                            :name=>'name_known_entity_id_un')
+    end
+  end
+
+  down do
+    alter_table :tags do
+      drop_foreign_key :known_entity_id
+      drop_constraint('name_known_entity_id_un', type: :unique)
+    end
+  end
+end

--- a/db/migrate/20150703014627_add_sha1_to_entity_id.rb
+++ b/db/migrate/20150703014627_add_sha1_to_entity_id.rb
@@ -1,0 +1,7 @@
+Sequel.migration do
+  change do
+    alter_table :entity_ids do
+      add_column :sha1, String, null: false
+    end
+  end
+end

--- a/db/migrate/20150703023921_add_raw_entity_descriptor_foreign_key_to_entity_id.rb
+++ b/db/migrate/20150703023921_add_raw_entity_descriptor_foreign_key_to_entity_id.rb
@@ -1,0 +1,8 @@
+Sequel.migration do
+  change do
+    alter_table :entity_ids do
+      add_foreign_key :raw_entity_descriptor_id, :raw_entity_descriptors, null: true,
+                      foreign_key_constraint_name: 'red_eid_fkey'
+    end
+  end
+end

--- a/db/migrate/20150703030108_update_entity_descriptor_foreign_key_on_entity_id.rb
+++ b/db/migrate/20150703030108_update_entity_descriptor_foreign_key_on_entity_id.rb
@@ -1,0 +1,13 @@
+Sequel.migration do
+  up do
+    alter_table :entity_ids do
+      set_column_allow_null(:entity_descriptor_id)
+    end
+  end
+
+  down do
+    alter_table :entity_ids do
+      set_column_not_allow_null(:entity_descriptor_id)
+    end
+  end
+end

--- a/db/migrate/20150708025727_remove_entity_id_from_known_entity.rb
+++ b/db/migrate/20150708025727_remove_entity_id_from_known_entity.rb
@@ -1,0 +1,13 @@
+Sequel.migration do
+  up do
+    alter_table :known_entities do
+      drop_column :entity_id
+    end
+  end
+
+  down do
+    alter_table :known_entities do
+      add_column :entity_id, String
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -166,7 +166,6 @@ Sequel.migration do
     
     create_table(:metadata_instances) do
       primary_key :id, :type=>"int(11)"
-      column :identifier, "varchar(255)"
       column :name, "varchar(255)", :null=>false
       column :extensions, "text"
       column :created_at, "datetime"
@@ -176,6 +175,8 @@ Sequel.migration do
       foreign_key :keypair_id, :keypairs, :type=>"int(11)", :null=>false, :key=>[:id]
       column :primary_tag, "varchar(255)", :null=>false
       column :all_entities, "tinyint(1)", :default=>true, :null=>false
+      column :federation_identifier, "varchar(255)", :null=>false
+      column :validity_period, "int(11)", :null=>false
       
       index [:keypair_id], :name=>:keypair_id
     end
@@ -779,5 +780,6 @@ Sequel.migration do
     self << "INSERT INTO `schema_migrations` (`filename`) VALUES ('20150415030131_add_enabled_to_raw_entity_descriptor.rb')"
     self << "INSERT INTO `schema_migrations` (`filename`) VALUES ('20150504231555_add_primary_tag_to_metadata_instance.rb')"
     self << "INSERT INTO `schema_migrations` (`filename`) VALUES ('20150504232739_add_all_entities_to_metadata_instance.rb')"
+    self << "INSERT INTO `schema_migrations` (`filename`) VALUES ('20150505032956_add_saml_fields_to_metadata_instance.rb')"
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -283,6 +283,7 @@ Sequel.migration do
     create_table(:entity_ids) do
       primary_key :id, :type=>"int(11)"
       foreign_key :entity_descriptor_id, :entity_descriptors, :type=>"int(11)", :null=>false, :key=>[:id]
+      column :sha1, "varchar(255)", :null=>false
       
       index [:entity_descriptor_id], :name=>:eid_ed_fkey
     end
@@ -783,5 +784,6 @@ Sequel.migration do
     self << "INSERT INTO `schema_migrations` (`filename`) VALUES ('20150505032956_add_saml_fields_to_metadata_instance.rb')"
     self << "INSERT INTO `schema_migrations` (`filename`) VALUES ('20150505052005_drop_entity_descriptor_from_tags.rb')"
     self << "INSERT INTO `schema_migrations` (`filename`) VALUES ('20150505052251_add_known_entity_foreign_key_to_tags.rb')"
+    self << "INSERT INTO `schema_migrations` (`filename`) VALUES ('20150703014627_add_sha1_to_entity_id.rb')"
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -174,6 +174,7 @@ Sequel.migration do
       column :ca_verify_depth, "int(11)"
       column :hash_algorithm, "varchar(255)", :null=>false
       foreign_key :keypair_id, :keypairs, :type=>"int(11)", :null=>false, :key=>[:id]
+      column :primary_tag, "varchar(255)", :null=>false
       
       index [:keypair_id], :name=>:keypair_id
     end
@@ -775,5 +776,6 @@ Sequel.migration do
     self << "INSERT INTO `schema_migrations` (`filename`) VALUES ('20150305230517_add_keypair_to_metadata_instances.rb')"
     self << "INSERT INTO `schema_migrations` (`filename`) VALUES ('20150415004025_add_enabled_to_entity_descriptor.rb')"
     self << "INSERT INTO `schema_migrations` (`filename`) VALUES ('20150415030131_add_enabled_to_raw_entity_descriptor.rb')"
+    self << "INSERT INTO `schema_migrations` (`filename`) VALUES ('20150504231555_add_primary_tag_to_metadata_instance.rb')"
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -70,7 +70,6 @@ Sequel.migration do
     
     create_table(:known_entities) do
       primary_key :id, :type=>"int(11)"
-      column :entity_id, "varchar(255)", :null=>false
       column :active, "tinyint(1)", :null=>false
       column :entity_source_id, "int(11)", :null=>false
       column :created_at, "datetime", :null=>false
@@ -789,5 +788,6 @@ Sequel.migration do
     self << "INSERT INTO `schema_migrations` (`filename`) VALUES ('20150703014627_add_sha1_to_entity_id.rb')"
     self << "INSERT INTO `schema_migrations` (`filename`) VALUES ('20150703023921_add_raw_entity_descriptor_foreign_key_to_entity_id.rb')"
     self << "INSERT INTO `schema_migrations` (`filename`) VALUES ('20150703030108_update_entity_descriptor_foreign_key_on_entity_id.rb')"
+    self << "INSERT INTO `schema_migrations` (`filename`) VALUES ('20150708025727_remove_entity_id_from_known_entity.rb')"
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -282,10 +282,12 @@ Sequel.migration do
     
     create_table(:entity_ids) do
       primary_key :id, :type=>"int(11)"
-      foreign_key :entity_descriptor_id, :entity_descriptors, :type=>"int(11)", :null=>false, :key=>[:id]
+      foreign_key :entity_descriptor_id, :entity_descriptors, :type=>"int(11)", :key=>[:id]
       column :sha1, "varchar(255)", :null=>false
+      foreign_key :raw_entity_descriptor_id, :raw_entity_descriptors, :type=>"int(11)", :key=>[:id]
       
       index [:entity_descriptor_id], :name=>:eid_ed_fkey
+      index [:raw_entity_descriptor_id], :name=>:red_eid_fkey
     end
     
     create_table(:idp_sso_descriptors) do
@@ -785,5 +787,7 @@ Sequel.migration do
     self << "INSERT INTO `schema_migrations` (`filename`) VALUES ('20150505052005_drop_entity_descriptor_from_tags.rb')"
     self << "INSERT INTO `schema_migrations` (`filename`) VALUES ('20150505052251_add_known_entity_foreign_key_to_tags.rb')"
     self << "INSERT INTO `schema_migrations` (`filename`) VALUES ('20150703014627_add_sha1_to_entity_id.rb')"
+    self << "INSERT INTO `schema_migrations` (`filename`) VALUES ('20150703023921_add_raw_entity_descriptor_foreign_key_to_entity_id.rb')"
+    self << "INSERT INTO `schema_migrations` (`filename`) VALUES ('20150703030108_update_entity_descriptor_foreign_key_on_entity_id.rb')"
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -500,13 +500,13 @@ Sequel.migration do
     create_table(:tags) do
       primary_key :id, :type=>"int(11)"
       column :name, "varchar(255)", :null=>false
-      foreign_key :entity_descriptor_id, :entity_descriptors, :type=>"int(11)", :key=>[:id]
       foreign_key :role_descriptor_id, :role_descriptors, :type=>"int(11)", :key=>[:id]
       column :created_at, "datetime"
       column :updated_at, "datetime"
+      foreign_key :known_entity_id, :known_entities, :type=>"int(11)", :key=>[:id]
       
-      index [:entity_descriptor_id], :name=>:entity_descriptor_id
-      index [:name, :entity_descriptor_id], :name=>:name_entity_descriptor_id_un, :unique=>true
+      index [:known_entity_id], :name=>:known_entity_id
+      index [:name, :known_entity_id], :name=>:name_known_entity_id_un, :unique=>true
       index [:name, :role_descriptor_id], :name=>:name_role_descriptor_id_un, :unique=>true
       index [:role_descriptor_id], :name=>:role_descriptor_id
     end
@@ -781,5 +781,7 @@ Sequel.migration do
     self << "INSERT INTO `schema_migrations` (`filename`) VALUES ('20150504231555_add_primary_tag_to_metadata_instance.rb')"
     self << "INSERT INTO `schema_migrations` (`filename`) VALUES ('20150504232739_add_all_entities_to_metadata_instance.rb')"
     self << "INSERT INTO `schema_migrations` (`filename`) VALUES ('20150505032956_add_saml_fields_to_metadata_instance.rb')"
+    self << "INSERT INTO `schema_migrations` (`filename`) VALUES ('20150505052005_drop_entity_descriptor_from_tags.rb')"
+    self << "INSERT INTO `schema_migrations` (`filename`) VALUES ('20150505052251_add_known_entity_foreign_key_to_tags.rb')"
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -175,6 +175,7 @@ Sequel.migration do
       column :hash_algorithm, "varchar(255)", :null=>false
       foreign_key :keypair_id, :keypairs, :type=>"int(11)", :null=>false, :key=>[:id]
       column :primary_tag, "varchar(255)", :null=>false
+      column :all_entities, "tinyint(1)", :default=>true, :null=>false
       
       index [:keypair_id], :name=>:keypair_id
     end
@@ -777,5 +778,6 @@ Sequel.migration do
     self << "INSERT INTO `schema_migrations` (`filename`) VALUES ('20150415004025_add_enabled_to_entity_descriptor.rb')"
     self << "INSERT INTO `schema_migrations` (`filename`) VALUES ('20150415030131_add_enabled_to_raw_entity_descriptor.rb')"
     self << "INSERT INTO `schema_migrations` (`filename`) VALUES ('20150504231555_add_primary_tag_to_metadata_instance.rb')"
+    self << "INSERT INTO `schema_migrations` (`filename`) VALUES ('20150504232739_add_all_entities_to_metadata_instance.rb')"
   end
 end

--- a/lib/metadata/saml.rb
+++ b/lib/metadata/saml.rb
@@ -72,6 +72,23 @@ module Metadata
       end
     end
 
+    def known_entity(ke)
+      if ke.entity_descriptor.try(:functioning?)
+        entity_descriptor(ke.entity_descriptor)
+      elsif ke.raw_entity_descriptor.try(:functioning?)
+        raw_entity_descriptor(ke.raw_entity_descriptor)
+      end
+    end
+
+    def root_entity_descriptor(ke)
+      if ke.entity_descriptor.try(:functioning?)
+        attributes = { ID: instance_id, validUntil: expires_at.xmlschema }
+        entity_descriptor(ke.entity_descriptor, attributes, true)
+      elsif ke.raw_entity_descriptor.try(:functioning?)
+        raw_entity_descriptor(ke.raw_entity_descriptor, true)
+      end
+    end
+
     C14N_METHOD = 'http://www.w3.org/2001/10/xml-exc-c14n#'
     TRANSFORM_METHODS = %w(
       http://www.w3.org/2000/09/xmldsig#enveloped-signature
@@ -180,24 +197,9 @@ module Metadata
       saml.AttributeValue(ns, attr_val.value)
     end
 
-    def root_entity_descriptor(ed)
-      return unless ed.functioning?
-
-      attributes = { ID: instance_id,
-                     validUntil: expires_at.xmlschema }
-      entity_descriptor(ed, attributes, true)
-    end
-
-    def known_entity(entity)
-      if entity.entity_descriptor.try(:functioning?)
-        entity_descriptor(entity.entity_descriptor)
-      elsif entity.raw_entity_descriptor.try(:functioning?)
-        raw_entity_descriptor(entity.raw_entity_descriptor)
-      end
-    end
-
-    def raw_entity_descriptor(red)
-      root << red.xml
+    def raw_entity_descriptor(red, root_node = false)
+      # TODO: Handle adding signature for root_node state
+      root << red.xml unless root_node
     end
 
     def entity_descriptor(ed, attributes = {}, root_node = false)

--- a/lib/metadata/saml.rb
+++ b/lib/metadata/saml.rb
@@ -202,6 +202,7 @@ module Metadata
 
     def entity_descriptor(ed, attributes = {}, root_node = false)
       root.EntityDescriptor(ns, attributes, entityID: ed.entity_id.uri) do |_|
+        signature_element if root_node
         entity_descriptor_extensions(ed, root_node)
 
         ed.idp_sso_descriptors.each do |idp|

--- a/lib/metadata/saml.rb
+++ b/lib/metadata/saml.rb
@@ -4,9 +4,8 @@ module Metadata
   class SAML
     include SAMLNamespaces
 
-    attr_reader :builder, :created_at, :expires_at, :instance_id,
-                :federation_identifier, :metadata_name, :metadata_instance,
-                :metadata_validity_period
+    attr_reader :builder, :created_at, :expires_at,
+                :instance_id, :metadata_instance
 
     protected
 
@@ -38,8 +37,8 @@ module Metadata
 
       @builder = Nokogiri::XML::Builder.new(encoding: 'UTF-8')
       @created_at = Time.now.utc
-      @expires_at = created_at + metadata_validity_period
-      @instance_id = "#{federation_identifier}" \
+      @expires_at = created_at + metadata_instance.validity_period
+      @instance_id = "#{metadata_instance.federation_identifier}" \
                      "#{created_at.to_formatted_s(:number)}"
     end
 
@@ -49,7 +48,7 @@ module Metadata
 
     def entities_descriptor(known_entities)
       attributes = { ID: instance_id,
-                     Name: metadata_name,
+                     Name: metadata_instance.name,
                      validUntil: expires_at.xmlschema }
 
       root.EntitiesDescriptor(ns, attributes) do |_|

--- a/lib/metadata/saml.rb
+++ b/lib/metadata/saml.rb
@@ -203,8 +203,8 @@ module Metadata
       # A dodgy hack to prevent Nokogiri from adding 'default' as a
       # namespace to xmlns elements moved from this document to our actual
       # EntityDescriptor builder, <default:IDPSSODescriptor> wtf Nokogiri...
-      xmlns_striped_input = red.xml.gsub(/xmlns=".+?"/, '')
-      parsed_xml = Nokogiri::XML(xmlns_striped_input, 'UTF-8')
+      xmlns_stripped_input = red.xml.gsub(/xmlns=".+?"/, '')
+      parsed_xml = Nokogiri::XML(xmlns_stripped_input, 'UTF-8')
 
       root.EntityDescriptor(ns, attributes, entityID: red.entity_id.uri) do |_|
         signature_element

--- a/spec/controllers/metadata_query_controller_spec.rb
+++ b/spec/controllers/metadata_query_controller_spec.rb
@@ -281,11 +281,6 @@ RSpec.describe MetadataQueryController, type: :controller do
               .send(:generate_descriptor_etag, entity_descriptor.known_entity)
           end
           context 'valid entity_descriptor' do
-            def run
-              get :specific_entity, primary_tag: primary_tag,
-                                    identifier: entity_id
-            end
-
             context 'initial request' do
               context 'uncached server side' do
                 context 'response' do
@@ -418,19 +413,49 @@ RSpec.describe MetadataQueryController, type: :controller do
       end
     end
 
-    context 'EntityDescriptor' do
-      let(:idp_sso_descriptor) { create :idp_sso_descriptor }
-      let(:entity_descriptor) { idp_sso_descriptor.entity_descriptor }
-      let(:entity_id) { entity_descriptor.entity_id.uri }
+    context 'With URI identifier' do
+      def run
+        get :specific_entity, primary_tag: primary_tag,
+                              identifier: entity_id
+      end
 
-      include_examples 'Specific Entity Descriptor'
+      context 'EntityDescriptor' do
+        let(:idp_sso_descriptor) { create :idp_sso_descriptor }
+        let(:entity_descriptor) { idp_sso_descriptor.entity_descriptor }
+        let(:entity_id) { entity_descriptor.entity_id.uri }
+
+        include_examples 'Specific Entity Descriptor'
+      end
+
+      context 'RawEntityDescriptor' do
+        let(:entity_descriptor) { create :raw_entity_descriptor }
+        let(:entity_id) { entity_descriptor.entity_id.uri }
+
+        include_examples 'Specific Entity Descriptor'
+      end
     end
 
-    context 'RawEntityDescriptor' do
-      let(:entity_descriptor) { create :raw_entity_descriptor }
-      let(:entity_id) { entity_descriptor.entity_id.uri }
+    context 'With sha1 identifier' do
+      def run
+        identifier = "{sha1}#{Digest::SHA1.hexdigest(entity_id)}"
+        get :specific_entity_sha1, primary_tag: primary_tag,
+                                   identifier: identifier
+      end
 
-      include_examples 'Specific Entity Descriptor'
+      context 'EntityDescriptor' do
+        let(:idp_sso_descriptor) { create :idp_sso_descriptor }
+        let(:entity_descriptor) { idp_sso_descriptor.entity_descriptor }
+        let(:entity_id) { entity_descriptor.entity_id.uri }
+
+        include_examples 'Specific Entity Descriptor'
+      end
+
+      context 'RawEntityDescriptor' do
+        let(:entity_descriptor) { create :raw_entity_descriptor }
+        let(:entity_id) { entity_descriptor.entity_id.uri }
+
+        include_examples 'Specific Entity Descriptor'
+      end
     end
   end
 

--- a/spec/controllers/metadata_query_controller_spec.rb
+++ b/spec/controllers/metadata_query_controller_spec.rb
@@ -33,6 +33,12 @@ RSpec.describe MetadataQueryController, type: :controller do
       end
 
       it { is_expected.to have_http_status(:not_found) }
+      it 'has relevant MUST/SHOULD headers per specification' do
+        expect(subject.headers).to include(
+          'Cache-Control' =>
+            'max-age=600, private'
+        )
+      end
     end
   end
 
@@ -122,6 +128,12 @@ RSpec.describe MetadataQueryController, type: :controller do
           context 'response' do
             subject { response }
             it { is_expected.to have_http_status(:not_found) }
+            it 'has relevant MUST/SHOULD headers per specification' do
+              expect(subject.headers).to include(
+                'Cache-Control' =>
+                  'max-age=600, private'
+              )
+            end
           end
         end
 
@@ -392,6 +404,12 @@ RSpec.describe MetadataQueryController, type: :controller do
             context 'response' do
               subject { response }
               it { is_expected.to have_http_status(:not_found) }
+              it 'has relevant MUST/SHOULD headers per specification' do
+                expect(subject.headers).to include(
+                  'Cache-Control' =>
+                    'max-age=600, private'
+                )
+              end
             end
           end
         end
@@ -479,6 +497,12 @@ RSpec.describe MetadataQueryController, type: :controller do
           context 'response' do
             subject { response }
             it { is_expected.to have_http_status(:not_found) }
+            it 'has relevant MUST/SHOULD headers per specification' do
+              expect(subject.headers).to include(
+                'Cache-Control' =>
+                  'max-age=600, private'
+              )
+            end
           end
         end
 

--- a/spec/controllers/metadata_query_controller_spec.rb
+++ b/spec/controllers/metadata_query_controller_spec.rb
@@ -280,7 +280,8 @@ RSpec.describe MetadataQueryController, type: :controller do
           create :metadata_instance, primary_tag: primary_tag
         end
         let(:etag) do
-          controller.send(:generate_descriptor_etag, entity_descriptor)
+          controller
+            .send(:generate_descriptor_etag, entity_descriptor.known_entity)
         end
         context 'valid entity_descriptor' do
           def run

--- a/spec/controllers/metadata_query_controller_spec.rb
+++ b/spec/controllers/metadata_query_controller_spec.rb
@@ -193,7 +193,7 @@ RSpec.describe MetadataQueryController, type: :controller do
             before do
               run
               @etag = response.headers['ETag']
-              @last_modified = response.headers['Last-Modified']
+              @last_modified = Time.rfc822(response.headers['Last-Modified'])
             end
 
             context 'ETags' do
@@ -321,7 +321,7 @@ RSpec.describe MetadataQueryController, type: :controller do
               before do
                 run
                 @etag = response.headers['ETag']
-                @last_modified = response.headers['Last-Modified']
+                @last_modified = Time.rfc822(response.headers['Last-Modified'])
               end
 
               context 'ETags' do
@@ -585,7 +585,7 @@ RSpec.describe MetadataQueryController, type: :controller do
             before do
               run
               @etag = response.headers['ETag']
-              @last_modified = response.headers['Last-Modified']
+              @last_modified = Time.rfc822(response.headers['Last-Modified'])
             end
 
             context 'ETags' do

--- a/spec/factories/entity_ids.rb
+++ b/spec/factories/entity_ids.rb
@@ -3,5 +3,10 @@ FactoryGirl.define do
     uri { "#{Faker::Internet.url}/shibboleth" }
 
     association :entity_descriptor
+
+    factory :raw_entity_id do
+      uri { "#{Faker::Internet.url}/shibboleth" }
+      association :raw_entity_descriptor
+    end
   end
 end

--- a/spec/factories/entity_ids.rb
+++ b/spec/factories/entity_ids.rb
@@ -1,12 +1,6 @@
 FactoryGirl.define do
   factory :entity_id do
     uri { "#{Faker::Internet.url}/shibboleth" }
-
     association :entity_descriptor
-
-    factory :raw_entity_id do
-      uri { "#{Faker::Internet.url}/shibboleth" }
-      association :raw_entity_descriptor
-    end
   end
 end

--- a/spec/factories/known_entities.rb
+++ b/spec/factories/known_entities.rb
@@ -11,5 +11,12 @@ FactoryGirl.define do
         ke.entity_descriptor = idp.entity_descriptor
       end
     end
+
+    trait :with_raw_entity_descriptor do
+      after(:create) do |ke|
+        red = create :raw_entity_descriptor, known_entity: ke
+        ke.entity_descriptor = red
+      end
+    end
   end
 end

--- a/spec/factories/known_entities.rb
+++ b/spec/factories/known_entities.rb
@@ -3,8 +3,13 @@ FactoryGirl.define do
     transient { hostname { "e.#{Faker::Internet.domain_name}" } }
 
     association :entity_source
-
-    entity_id { "https://#{hostname}/shibboleth" }
     active true
+
+    trait :with_idp do
+      after(:create) do |ke|
+        idp = create :idp_sso_descriptor
+        ke.entity_descriptor = idp.entity_descriptor
+      end
+    end
   end
 end

--- a/spec/factories/metadata_instances.rb
+++ b/spec/factories/metadata_instances.rb
@@ -3,7 +3,11 @@ FactoryGirl.define do
     association :keypair
 
     name { Faker::Internet.domain_name }
+
     hash_algorithm 'sha256'
+    validity_period { 1.week }
+    federation_identifier { Faker::Lorem.word }
+
     primary_tag { Faker::Lorem.word }
     all_entities true
 

--- a/spec/factories/metadata_instances.rb
+++ b/spec/factories/metadata_instances.rb
@@ -4,6 +4,7 @@ FactoryGirl.define do
 
     name { Faker::Internet.domain_name }
     hash_algorithm 'sha256'
+    primary_tag { Faker::Lorem.word }
 
     after :create do | mi |
       create(:mdrpi_publication_info, metadata_instance: mi)

--- a/spec/factories/metadata_instances.rb
+++ b/spec/factories/metadata_instances.rb
@@ -5,6 +5,7 @@ FactoryGirl.define do
     name { Faker::Internet.domain_name }
     hash_algorithm 'sha256'
     primary_tag { Faker::Lorem.word }
+    all_entities true
 
     after :create do | mi |
       create(:mdrpi_publication_info, metadata_instance: mi)

--- a/spec/factories/raw_entity_descriptors.rb
+++ b/spec/factories/raw_entity_descriptors.rb
@@ -21,5 +21,9 @@ FactoryGirl.define do
         </EntityDescriptor>
       EOF
     end
+
+    after :create do |red|
+      red.entity_id = create :raw_entity_id, raw_entity_descriptor: red
+    end
   end
 end

--- a/spec/factories/raw_entity_descriptors.rb
+++ b/spec/factories/raw_entity_descriptors.rb
@@ -1,17 +1,18 @@
 FactoryGirl.define do
   factory :raw_entity_descriptor do
+    transient do
+      hostname { "raw.#{Faker::Internet.domain_name}" }
+      entity_id_uri { "https://#{hostname}/shibboleth" }
+    end
+
     enabled true
 
-    transient { hostname { "raw.#{Faker::Internet.domain_name}" } }
-
-    known_entity do
-      create(:known_entity, entity_id: "https://#{hostname}/idp/shibboleth")
-    end
+    association :known_entity
 
     xml do
       <<-EOF.strip_heredoc
         <EntityDescriptor xmlns="urn:oasis:names:tc:SAML:2.0:metadata"
-            entityID="#{known_entity.entity_id}">
+            entityID="#{entity_id_uri}">
           <AttributeAuthorityDescriptor
               protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol">
             <AttributeService
@@ -22,8 +23,9 @@ FactoryGirl.define do
       EOF
     end
 
-    after :create do |red|
-      red.entity_id = create :raw_entity_id, raw_entity_descriptor: red
+    after :create do |red, eval|
+      red.entity_id = create :raw_entity_id, uri: eval.entity_id_uri,
+                                             raw_entity_descriptor: red
     end
   end
 end

--- a/spec/factories/raw_entity_ids.rb
+++ b/spec/factories/raw_entity_ids.rb
@@ -1,0 +1,6 @@
+FactoryGirl.define do
+  factory :raw_entity_id, class: EntityId do
+    uri { "#{Faker::Internet.url}/shibboleth" }
+    association :raw_entity_descriptor
+  end
+end

--- a/spec/factories/tags.rb
+++ b/spec/factories/tags.rb
@@ -1,16 +1,16 @@
 FactoryGirl.define do
   factory :tag do
-    name { Faker::Lorem.characters }
-    association :entity_descriptor
+    name { Faker::Lorem.word }
+    association :known_entity
   end
 
-  factory :entity_descriptor_tag, class: 'Tag' do
-    name { Faker::Lorem.characters }
-    association :entity_descriptor
+  factory :known_entity_tag, class: 'Tag' do
+    name { Faker::Lorem.word }
+    association :known_entity
   end
 
   factory :role_descriptor_tag, class: 'Tag' do
-    name { Faker::Lorem.characters }
+    name { Faker::Lorem.word }
     association :role_descriptor
   end
 end

--- a/spec/jobs/update_entity_source_spec.rb
+++ b/spec/jobs/update_entity_source_spec.rb
@@ -101,8 +101,8 @@ RSpec.describe UpdateEntitySource do
 
     context 'when the entity already exists' do
       let!(:entity) do
-        KnownEntity.create(entity_source: subject, active: true,
-                           entity_id: entity_id)
+        create :known_entity, entity_source: subject, active: true,
+                              entity_id: entity_id
       end
 
       it 'uses the existing entity' do
@@ -115,7 +115,7 @@ RSpec.describe UpdateEntitySource do
 
       context 'when the raw entity descriptor already exists' do
         let!(:red) do
-          RawEntityDescriptor.create(xml: old_xml, known_entity: entity)
+          create :raw_entity_descriptor, xml: old_xml, known_entity: entity
         end
         let(:hostname) { URI.parse(entity.entity_id).hostname }
 
@@ -200,12 +200,12 @@ RSpec.describe UpdateEntitySource do
     end
 
     let!(:other_entity) do
-      KnownEntity.create(entity_source: subject, active: true,
-                         entity_id: entity_ids[0])
+      create :known_entity, entity_source: subject, active: true,
+                            entity_id: entity_ids[0]
     end
 
     let!(:other_red) do
-      RawEntityDescriptor.create(xml: old_xml, known_entity: other_entity)
+      create :raw_entity_descriptor, xml: old_xml, known_entity: other_entity
     end
 
     it 'removes the known entity' do

--- a/spec/jobs/update_entity_source_spec.rb
+++ b/spec/jobs/update_entity_source_spec.rb
@@ -101,23 +101,16 @@ RSpec.describe UpdateEntitySource do
 
     context 'when the entity already exists' do
       let!(:entity) do
-        create :known_entity, entity_source: subject, active: true,
-                              entity_id: entity_id
-      end
-
-      it 'uses the existing entity' do
-        expect { run }.not_to change(KnownEntity, :count)
-      end
-
-      it 'creates the raw entity descriptor' do
-        expect { run }.to change(RawEntityDescriptor, :count).by(1)
+        create :known_entity, entity_source: subject, active: true
       end
 
       context 'when the raw entity descriptor already exists' do
         let!(:red) do
-          create :raw_entity_descriptor, xml: old_xml, known_entity: entity
+          create :raw_entity_descriptor, xml: old_xml,
+                                         entity_id_uri: entity_id,
+                                         known_entity: entity
         end
-        let(:hostname) { URI.parse(entity.entity_id).hostname }
+        let(:hostname) { URI.parse(entity_id).hostname }
 
         let(:old_xml) do
           <<-EOF.strip_heredoc
@@ -200,12 +193,13 @@ RSpec.describe UpdateEntitySource do
     end
 
     let!(:other_entity) do
-      create :known_entity, entity_source: subject, active: true,
-                            entity_id: entity_ids[0]
+      create :known_entity, entity_source: subject, active: true
     end
 
     let!(:other_red) do
-      create :raw_entity_descriptor, xml: old_xml, known_entity: other_entity
+      create :raw_entity_descriptor, xml: old_xml,
+                                     known_entity: other_entity,
+                                     entity_id_uri: entity_ids[0]
     end
 
     it 'removes the known entity' do

--- a/spec/metadata/saml_spec.rb
+++ b/spec/metadata/saml_spec.rb
@@ -401,7 +401,7 @@ RSpec.describe Metadata::SAML do
 
   context 'ds:Signature' do
     let(:entity) { create(:idp_sso_descriptor).entity_descriptor }
-    before { subject.root_entity_descriptor(entity) }
+    before { subject.root_entity_descriptor(entity.known_entity) }
     include_examples 'ds:Signature xml' do
       let(:root_node) { 'EntityDescriptor' }
     end

--- a/spec/metadata/saml_spec.rb
+++ b/spec/metadata/saml_spec.rb
@@ -4,10 +4,7 @@ require 'metadata/saml'
 
 RSpec.describe Metadata::SAML do
   subject do
-    Metadata::SAML.new(metadata_instance: metadata_instance,
-                       federation_identifier: federation_identifier,
-                       metadata_name: metadata_name,
-                       metadata_validity_period: metadata_validity_period)
+    Metadata::SAML.new(metadata_instance: metadata_instance)
   end
 
   let(:federation_identifier) { Faker::Internet.domain_word }
@@ -17,7 +14,10 @@ RSpec.describe Metadata::SAML do
   let(:hash_algorithm) { 'sha256' }
 
   let(:metadata_instance) do
-    create(:metadata_instance, hash_algorithm: hash_algorithm)
+    create(:metadata_instance, hash_algorithm: hash_algorithm,
+                               name: metadata_name,
+                               federation_identifier: federation_identifier,
+                               validity_period: metadata_validity_period)
   end
 
   let(:builder) { subject.builder }

--- a/spec/metadata/saml_spec.rb
+++ b/spec/metadata/saml_spec.rb
@@ -390,14 +390,16 @@ RSpec.describe Metadata::SAML do
   end
 
   context 'ds:Signature' do
-    let(:entities) { [create(:raw_entity_descriptor).known_entity] }
+    let(:entities) do
+      [create(:idp_sso_descriptor).entity_descriptor.known_entity]
+    end
     before { subject.entities_descriptor(entities) }
     include_examples 'ds:Signature xml' do
       let(:root_node) { 'EntitiesDescriptor' }
     end
   end
 
-  context 'ds:Signature', focus: true do
+  context 'ds:Signature' do
     let(:entity) { create(:idp_sso_descriptor).entity_descriptor }
     before { subject.root_entity_descriptor(entity) }
     include_examples 'ds:Signature xml' do

--- a/spec/metadata/saml_spec.rb
+++ b/spec/metadata/saml_spec.rb
@@ -392,6 +392,16 @@ RSpec.describe Metadata::SAML do
   context 'ds:Signature' do
     let(:entities) { [create(:raw_entity_descriptor).known_entity] }
     before { subject.entities_descriptor(entities) }
-    include_examples 'ds:Signature xml'
+    include_examples 'ds:Signature xml' do
+      let(:root_node) { 'EntitiesDescriptor' }
+    end
+  end
+
+  context 'ds:Signature', focus: true do
+    let(:entity) { create(:idp_sso_descriptor).entity_descriptor }
+    before { subject.root_entity_descriptor(entity) }
+    include_examples 'ds:Signature xml' do
+      let(:root_node) { 'EntityDescriptor' }
+    end
   end
 end

--- a/spec/metadata/saml_spec.rb
+++ b/spec/metadata/saml_spec.rb
@@ -399,8 +399,47 @@ RSpec.describe Metadata::SAML do
     end
   end
 
-  context 'ds:Signature' do
+  context 'ds:Signature Root EntityDescriptor' do
     let(:entity) { create(:idp_sso_descriptor).entity_descriptor }
+    before { subject.root_entity_descriptor(entity.known_entity) }
+    include_examples 'ds:Signature xml' do
+      let(:root_node) { 'EntityDescriptor' }
+    end
+  end
+
+  context 'ds:Signature Root RawEntityDescriptor' do
+    let(:ed_xml) do
+      <<-EOF.strip_heredoc
+        <EntityDescriptor xmlns="urn:oasis:names:tc:SAML:2.0:metadata"
+            entityID="https://test.example.com/idp/shibboleth"
+            xmlns:mdrpi="urn:oasis:names:tc:SAML:metadata:rpi">
+          <Extensions>
+            <mdrpi:PublicationInfo publisher="http://luettgen.com/maximilian"
+              creationInstant="2015-07-06T22:33:00Z"
+              publicationId="hoppekuhn20150706223300">
+              <mdrpi:UsagePolicy xml:lang="en">
+                http://www.edugain.org/policy/metadata-tou_1_0.txt
+              </mdrpi:UsagePolicy>
+            </mdrpi:PublicationInfo>
+            <mdrpi:RegistrationInfo
+              registrationAuthority="http://sauerheidenreich.net/einar_upton"
+              registrationInstant="2015-07-06T22:33:00Z">
+              <mdrpi:RegistrationPolicy xml:lang="en">
+                http://trantow.info/ella
+              </mdrpi:RegistrationPolicy>
+            </mdrpi:RegistrationInfo>
+          </Extensions>
+          <AttributeAuthorityDescriptor
+              protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol">
+            <AttributeService
+                Binding="urn:oasis:names:tc:SAML:2.0:bindings:SOAP"
+                Location="https://example.com/idp/profile/AttributeQuery/SOAP"/>
+          </AttributeAuthorityDescriptor>
+        </EntityDescriptor>
+      EOF
+    end
+
+    let(:entity) { create(:raw_entity_descriptor, xml: ed_xml) }
     before { subject.root_entity_descriptor(entity.known_entity) }
     include_examples 'ds:Signature xml' do
       let(:root_node) { 'EntityDescriptor' }

--- a/spec/models/entity_descriptor_spec.rb
+++ b/spec/models/entity_descriptor_spec.rb
@@ -2,7 +2,6 @@ require 'rails_helper'
 
 describe EntityDescriptor do
   it_behaves_like 'a basic model'
-  it_behaves_like 'a taggable model', :entity_descriptor_tag, :entity_descriptor
 
   it { is_expected.to validate_presence :known_entity }
   it { is_expected.to validate_presence :entity_id }

--- a/spec/models/entity_id_spec.rb
+++ b/spec/models/entity_id_spec.rb
@@ -1,9 +1,31 @@
 require 'rails_helper'
+require 'digest/sha1'
 
 RSpec.describe EntityId, type: :model do
   context 'extends saml uri' do
     it { is_expected.to have_many_to_one :entity_descriptor }
     it { is_expected.to validate_presence :entity_descriptor }
+    it { is_expected.to validate_presence :sha1 }
     it { is_expected.to validate_max_length 1024, :uri }
+  end
+
+  context 'validation' do
+    subject { build :entity_id }
+
+    it 'has no sha1 value before validation' do
+      expect(subject.sha1).to be_nil
+    end
+
+    context 'post validation' do
+      before { subject.valid? }
+
+      it 'has sha1 value' do
+        expect(subject.sha1).not_to be_nil
+      end
+
+      it 'calculates sha1 from uri' do
+        expect(subject.sha1).to eq(Digest::SHA1.hexdigest subject.uri)
+      end
+    end
   end
 end

--- a/spec/models/entity_id_spec.rb
+++ b/spec/models/entity_id_spec.rb
@@ -4,7 +4,8 @@ require 'digest/sha1'
 RSpec.describe EntityId, type: :model do
   context 'extends saml uri' do
     it { is_expected.to have_many_to_one :entity_descriptor }
-    it { is_expected.to validate_presence :entity_descriptor }
+    it { is_expected.to have_many_to_one :raw_entity_descriptor }
+
     it { is_expected.to validate_presence :sha1 }
     it { is_expected.to validate_max_length 1024, :uri }
   end
@@ -25,6 +26,32 @@ RSpec.describe EntityId, type: :model do
 
       it 'calculates sha1 from uri' do
         expect(subject.sha1).to eq(Digest::SHA1.hexdigest subject.uri)
+      end
+    end
+
+    context 'ownership' do
+      subject { create :entity_id, entity_descriptor: nil }
+
+      it 'must be owned' do
+        expect(subject).not_to be_valid
+      end
+
+      it 'owned by entity_descriptor' do
+        subject.entity_descriptor = create :entity_descriptor
+        expect(subject).to be_valid
+      end
+
+      it 'owned by raw_entity_descriptor' do
+        subject.raw_entity_descriptor = create :raw_entity_descriptor
+
+        expect(subject).to be_valid
+      end
+
+      it 'cant have multiple owners' do
+        subject.entity_descriptor = create :entity_descriptor
+        subject.raw_entity_descriptor = create :raw_entity_descriptor
+
+        expect(subject).not_to be_valid
       end
     end
   end

--- a/spec/models/entity_id_spec.rb
+++ b/spec/models/entity_id_spec.rb
@@ -36,12 +36,12 @@ RSpec.describe EntityId, type: :model do
         expect(subject).not_to be_valid
       end
 
-      it 'owned by entity_descriptor' do
+      it 'can be owned by entity_descriptor' do
         subject.entity_descriptor = create :entity_descriptor
         expect(subject).to be_valid
       end
 
-      it 'owned by raw_entity_descriptor' do
+      it 'can be owned by raw_entity_descriptor' do
         subject.raw_entity_descriptor = create :raw_entity_descriptor
 
         expect(subject).to be_valid
@@ -53,6 +53,18 @@ RSpec.describe EntityId, type: :model do
 
         expect(subject).not_to be_valid
       end
+    end
+  end
+
+  describe '#parent' do
+    it 'provides owning EntityDescriptor' do
+      subject { create :entity_id }
+      expect(subject.parent).to eq(subject.entity_descriptor)
+    end
+
+    it 'provides owning RawEntityDescriptor' do
+      subject { create :raw_entity_id }
+      expect(subject.parent).to eq(subject.raw_entity_descriptor)
     end
   end
 end

--- a/spec/models/entity_source_spec.rb
+++ b/spec/models/entity_source_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe EntitySource do
     end
 
     it 'rejects a url which does not parse' do
-      subject.url = 'https://fed.test_example.com/metadata/full.xml'
+      subject.url = 'https://fed.test example.com/metadata/full.xml'
       expect(subject).not_to be_valid
     end
   end

--- a/spec/models/known_entity_spec.rb
+++ b/spec/models/known_entity_spec.rb
@@ -2,6 +2,7 @@ require 'rails_helper'
 
 RSpec.describe KnownEntity do
   it_behaves_like 'a basic model'
+  it_behaves_like 'a taggable model', :known_entity_tag, :known_entity
 
   it { is_expected.to validate_presence(:active) }
   it { is_expected.to validate_presence(:entity_source) }

--- a/spec/models/metadata_instance_spec.rb
+++ b/spec/models/metadata_instance_spec.rb
@@ -9,6 +9,7 @@ describe MetadataInstance do
   it { is_expected.to validate_presence :name }
   it { is_expected.not_to validate_presence :publication_info }
   it { is_expected.to validate_presence :hash_algorithm }
+  it { is_expected.to validate_presence :primary_tag }
   it { is_expected.to validate_includes(%w(sha1 sha256), :hash_algorithm) }
 
   context 'optional attributes' do

--- a/spec/models/metadata_instance_spec.rb
+++ b/spec/models/metadata_instance_spec.rb
@@ -3,7 +3,6 @@ require 'rails_helper'
 describe MetadataInstance do
   it_behaves_like 'a basic model'
 
-  it { is_expected.to have_one_to_many :entity_descriptors }
   it { is_expected.to have_one_to_many :ca_key_infos }
   it { is_expected.to have_many_to_one :keypair }
   it { is_expected.to validate_presence :keypair }

--- a/spec/models/metadata_instance_spec.rb
+++ b/spec/models/metadata_instance_spec.rb
@@ -9,8 +9,9 @@ describe MetadataInstance do
   it { is_expected.to validate_presence :name }
   it { is_expected.not_to validate_presence :publication_info }
   it { is_expected.to validate_presence :hash_algorithm }
-  it { is_expected.to validate_presence :primary_tag }
   it { is_expected.to validate_includes(%w(sha1 sha256), :hash_algorithm) }
+  it { is_expected.to validate_presence :primary_tag }
+  it { is_expected.to validate_presence :all_entities }
 
   context 'optional attributes' do
     it { is_expected.to have_one_to_one :registration_info }

--- a/spec/models/metadata_instance_spec.rb
+++ b/spec/models/metadata_instance_spec.rb
@@ -10,6 +10,9 @@ describe MetadataInstance do
   it { is_expected.not_to validate_presence :publication_info }
   it { is_expected.to validate_presence :hash_algorithm }
   it { is_expected.to validate_includes(%w(sha1 sha256), :hash_algorithm) }
+  it { is_expected.to validate_presence :federation_identifier }
+  it { is_expected.to validate_presence :validity_period }
+
   it { is_expected.to validate_presence :primary_tag }
   it { is_expected.to validate_presence :all_entities }
 

--- a/spec/models/raw_entity_descriptor_spec.rb
+++ b/spec/models/raw_entity_descriptor_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe RawEntityDescriptor do
   it_behaves_like 'a basic model'
 
   it { is_expected.to have_many_to_one(:known_entity) }
+  it { is_expected.to validate_presence :entity_id }
 
   it { is_expected.to validate_presence(:xml) }
   it { is_expected.to validate_max_length(65_535, :xml) }

--- a/spec/models/tag_spec.rb
+++ b/spec/models/tag_spec.rb
@@ -4,16 +4,16 @@ RSpec.describe Tag, type: :model do
   it_behaves_like 'a basic model'
 
   it { is_expected.to validate_presence :name }
-  it { is_expected.to have_many_to_one :entity_descriptor }
+  it { is_expected.to have_many_to_one :known_entity }
   it { is_expected.to have_many_to_one :role_descriptor }
 
   let(:role_descriptor) { create(:role_descriptor) }
-  let(:entity_descriptor) { create(:entity_descriptor) }
+  let(:known_entity) { create(:known_entity) }
 
   let(:tag_name) { Faker::Lorem.word }
 
   context 'with no owner' do
-    let(:tag) { build(:tag, entity_descriptor: nil, role_descriptor: nil) }
+    let(:tag) { build(:tag, known_entity: nil, role_descriptor: nil) }
     subject { tag }
     it { is_expected.to_not be_valid }
     context 'the error message' do
@@ -21,7 +21,7 @@ RSpec.describe Tag, type: :model do
       subject { tag.errors }
       it 'is expected to be a single owner validation' do
         expect(subject).to eq(ownership: ['Must be owned by one of' \
-                                      ' entity_descriptor, role_descriptor'])
+                                      ' known_entity, role_descriptor'])
       end
     end
   end
@@ -29,7 +29,7 @@ RSpec.describe Tag, type: :model do
   context 'with one owner' do
     subject do
       build(:tag, role_descriptor: role_descriptor,
-                  entity_descriptor: nil)
+                  known_entity: nil)
     end
     it { is_expected.to be_valid }
   end
@@ -37,7 +37,7 @@ RSpec.describe Tag, type: :model do
   context 'with more than one owner' do
     let(:tag) do
       build(:tag, role_descriptor: role_descriptor,
-                  entity_descriptor: entity_descriptor)
+                  known_entity: known_entity)
     end
     subject { tag }
     it { is_expected.to_not be_valid }
@@ -46,7 +46,7 @@ RSpec.describe Tag, type: :model do
       subject { tag.errors }
       it 'is expected to be a single owner validation' do
         expect(subject).to eq(ownership: ['Cannot be owned by more than one' \
-                                      ' of entity_descriptor, role_descriptor'])
+                                      ' of known_entity, role_descriptor'])
       end
     end
   end
@@ -72,25 +72,25 @@ RSpec.describe Tag, type: :model do
       end
     end
 
-    context 'entity_descriptor tag with same name' do
+    context 'known_entity tag with same name' do
       subject do
-        build(:entity_descriptor_tag,
-              entity_descriptor: entity_descriptor, name: tag_name)
+        build(:known_entity_tag,
+              known_entity: known_entity, name: tag_name)
       end
       before { tag.valid? }
       it { is_expected.to be_valid }
     end
   end
 
-  context '[name, entity_descriptor] uniqueness' do
+  context '[name, known_entity] uniqueness' do
     before do
-      create(:entity_descriptor_tag,
-             entity_descriptor: entity_descriptor, name: tag_name)
+      create(:known_entity_tag,
+             known_entity: known_entity, name: tag_name)
     end
 
     let(:tag) do
-      build(:entity_descriptor_tag,
-            entity_descriptor: entity_descriptor, name: tag_name)
+      build(:known_entity_tag,
+            known_entity: known_entity, name: tag_name)
     end
 
     subject { tag }
@@ -101,7 +101,7 @@ RSpec.describe Tag, type: :model do
       subject { tag.errors }
       it 'is expected to be a uniqueness validation' do
         expect(subject)
-          .to eq([:name, :entity_descriptor] => ['is already taken'])
+          .to eq([:name, :known_entity] => ['is already taken'])
       end
     end
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -12,6 +12,7 @@ Timecop.safe_mode = true
 RSpec.configure do |config|
   config.fixture_path = "#{::Rails.root}/spec/fixtures"
   config.include FactoryGirl::Syntax::Methods
+  config.include Rails.application.routes.url_helpers
 
   # Use Sequel matchers and transactions
   config.include RspecSequel::Matchers

--- a/spec/routes/metadata_query_controller_spec.rb
+++ b/spec/routes/metadata_query_controller_spec.rb
@@ -1,0 +1,48 @@
+require 'rails_helper'
+
+RSpec.describe 'Routes for MetadataQueryController', type: :routing do
+  let(:primary_tag) { Faker::Lorem.word }
+  let(:identifier) { Faker::Internet.url }
+  let(:sha1_identifier) { Digest::SHA1.hexdigest identifier }
+  let(:basic_identifier) { Faker::Lorem.word }
+
+  it 'routes /:primary_tag/entities to #all_entities' do
+    expect(get("/#{primary_tag}/entities"))
+      .to route_to(
+        controller: 'metadata_query',
+        action: 'all_entities',
+        primary_tag: primary_tag
+      )
+  end
+
+  it 'routes /:primary_tag/entities/:identifier to #specific_entity' do
+    expect(get("/#{primary_tag}/entities/#{identifier}"))
+      .to route_to(
+        controller: 'metadata_query',
+        action: 'specific_entity',
+        primary_tag: primary_tag,
+        identifier: identifier
+      )
+  end
+
+  it 'routes /:primary_tag/entities/:identifier to #specific_entity_sha1' do
+    uri = URI.encode("/#{primary_tag}/entities/{sha1}#{sha1_identifier}")
+    expect(get(uri))
+      .to route_to(
+        controller: 'metadata_query',
+        action: 'specific_entity_sha1',
+        primary_tag: primary_tag,
+        identifier: "{sha1}#{sha1_identifier}"
+      )
+  end
+
+  it 'routes /:primary_tag/entities/:basic_identifier to #tagged_entities' do
+    expect(get("/#{primary_tag}/entities/#{basic_identifier}"))
+      .to route_to(
+        controller: 'metadata_query',
+        action: 'tagged_entities',
+        primary_tag: primary_tag,
+        identifier: basic_identifier
+      )
+  end
+end

--- a/spec/support/metadata/entity_descriptor.rb
+++ b/spec/support/metadata/entity_descriptor.rb
@@ -126,7 +126,6 @@ RSpec.shared_examples 'EntityDescriptor xml' do
       end
     end
 
-
     context 'Extensions' do
       it 'creates a mdrpi:PublisherInfo' do
         expect(xml).to have_xpath(all_publication_infos, count: 1)

--- a/spec/support/metadata/entity_descriptor.rb
+++ b/spec/support/metadata/entity_descriptor.rb
@@ -126,6 +126,7 @@ RSpec.shared_examples 'EntityDescriptor xml' do
       end
     end
 
+
     context 'Extensions' do
       it 'creates a mdrpi:PublisherInfo' do
         expect(xml).to have_xpath(all_publication_infos, count: 1)

--- a/spec/support/metadata/entity_descriptor.rb
+++ b/spec/support/metadata/entity_descriptor.rb
@@ -1,5 +1,6 @@
 RSpec.shared_examples 'EntityDescriptor xml' do
   let(:entity_descriptor) { create :entity_descriptor }
+  let(:known_entity) { entity_descriptor.known_entity }
   let(:entity_descriptor_path) { '/EntityDescriptor' }
   let(:extensions_path) { "#{entity_descriptor_path}/Extensions" }
   let(:registration_info_path) { "#{extensions_path}/mdrpi:RegistrationInfo" }
@@ -108,7 +109,7 @@ RSpec.shared_examples 'EntityDescriptor xml' do
   end
 
   context 'Root EntityDescriptor' do
-    before { subject.root_entity_descriptor(entity_descriptor) }
+    before { subject.root_entity_descriptor(known_entity) }
     include_examples 'md:EntityDescriptor xml'
 
     context 'attributes' do
@@ -136,7 +137,7 @@ RSpec.shared_examples 'EntityDescriptor xml' do
   context 'Root EntityDescriptor - non functioning' do
     before do
       entity_descriptor.enabled = false
-      subject.root_entity_descriptor(entity_descriptor)
+      subject.root_entity_descriptor(known_entity)
     end
 
     it 'is not created' do

--- a/spec/support/metadata/raw_entity_descriptor.rb
+++ b/spec/support/metadata/raw_entity_descriptor.rb
@@ -16,12 +16,34 @@ RSpec.shared_examples 'RawEntityDescriptor xml' do
   let(:raw_entity_descriptor) { create(:raw_entity_descriptor, xml: ed_xml) }
   let(:known_entity) { raw_entity_descriptor.known_entity }
   let(:entity_source) { known_entity.entity_source }
+  let(:entity_descriptor_path) { '/EntityDescriptor' }
 
-  before { subject.entities_descriptor([known_entity]) }
+  context 'Root EntityDescriptor'do
+    before { subject.root_entity_descriptor(known_entity) }
 
-  it 'is included in the output' do
-    xpath = '//EntityDescriptor' \
-            '[@entityID="https://test.example.com/idp/shibboleth"]'
-    expect(xml).to have_xpath(xpath)
+    context 'attributes' do
+      let(:node) { xml.find(:xpath, entity_descriptor_path) }
+
+      around { |example| Timecop.freeze { example.run } }
+
+      it 'sets ID' do
+        expect(node['ID']).to eq(subject.instance_id)
+          .and start_with(federation_identifier)
+      end
+      it 'sets validUntil' do
+        expect(node['validUntil'])
+          .to eq((Time.now.utc + metadata_validity_period).xmlschema)
+      end
+    end
+  end
+
+  context 'EntityDescriptor' do
+    before { subject.entities_descriptor([known_entity]) }
+
+    it 'is included in the output' do
+      xpath = '//EntityDescriptor' \
+              '[@entityID="https://test.example.com/idp/shibboleth"]'
+      expect(xml).to have_xpath(xpath)
+    end
   end
 end

--- a/spec/support/metadata/signature.rb
+++ b/spec/support/metadata/signature.rb
@@ -96,18 +96,18 @@ RSpec.shared_examples 'ds:Signature xml' do
   context 'with a signed document' do
     let(:schema) { Nokogiri::XML::Schema.new(File.open('schema/top.xsd', 'r')) }
     let(:validation_errors) { schema.validate(Nokogiri::XML.parse(raw_xml)) }
-    let(:raw_xml) { subject.sign }
+    before { subject.sign }
 
     let(:c14n_xml) do
-      doc = subject.builder.doc.dup
+      doc = builder.doc.dup
       doc.xpath('//ds:Signature').each(&:remove)
       doc.canonicalize(Nokogiri::XML::XML_C14N_EXCLUSIVE_1_0)
     end
 
     let(:c14n_signed_info) do
-      doc = Nokogiri::XML::Document.new
-      doc << signed_info.native.dup
-      doc.canonicalize(Nokogiri::XML::XML_C14N_EXCLUSIVE_1_0)
+      doc = builder.doc.dup
+      doc.at_xpath("#{sig_xpath}/ds:SignedInfo")
+        .canonicalize(Nokogiri::XML::XML_C14N_EXCLUSIVE_1_0)
     end
 
     context 'using sha1' do
@@ -133,7 +133,6 @@ RSpec.shared_examples 'ds:Signature xml' do
       end
 
       it 'includes the signature value' do
-        binding.pry
         rsa_sig = key.sign(OpenSSL::Digest::SHA1.new, c14n_signed_info)
         expected = Base64.encode64(rsa_sig).strip
 

--- a/spec/support/metadata/signature.rb
+++ b/spec/support/metadata/signature.rb
@@ -1,5 +1,5 @@
 RSpec.shared_examples 'ds:Signature xml' do
-  let(:sig_xpath) { '/*[local-name() = "EntitiesDescriptor"]/ds:Signature' }
+  let(:sig_xpath) { "/*[local-name() = \"#{root_node}\"]/ds:Signature" }
   let(:signature) { xml.find(:xpath, sig_xpath) }
   let(:signed_info) { xml.find(:xpath, "#{sig_xpath}/ds:SignedInfo") }
   let(:reference) { signed_info.find(:xpath, 'ds:Reference') }
@@ -133,6 +133,7 @@ RSpec.shared_examples 'ds:Signature xml' do
       end
 
       it 'includes the signature value' do
+        binding.pry
         rsa_sig = key.sign(OpenSSL::Digest::SHA1.new, c14n_signed_info)
         expected = Base64.encode64(rsa_sig).strip
 

--- a/spec/support/metadata/signature.rb
+++ b/spec/support/metadata/signature.rb
@@ -96,7 +96,7 @@ RSpec.shared_examples 'ds:Signature xml' do
   context 'with a signed document' do
     let(:schema) { Nokogiri::XML::Schema.new(File.open('schema/top.xsd', 'r')) }
     let(:validation_errors) { schema.validate(Nokogiri::XML.parse(raw_xml)) }
-    before { subject.sign }
+    let!(:raw_xml) { subject.sign }
 
     let(:c14n_xml) do
       doc = builder.doc.dup

--- a/spec/support/metadata/signature.rb
+++ b/spec/support/metadata/signature.rb
@@ -1,5 +1,6 @@
 RSpec.shared_examples 'ds:Signature xml' do
-  let(:sig_xpath) { "/*[local-name() = \"#{root_node}\"]/ds:Signature" }
+  let(:sig_xpath) { "/#{root_node}/ds:Signature" }
+  let(:doc_sig_xpath) { "/xmlns:#{root_node}/ds:Signature" }
   let(:signature) { xml.find(:xpath, sig_xpath) }
   let(:signed_info) { xml.find(:xpath, "#{sig_xpath}/ds:SignedInfo") }
   let(:reference) { signed_info.find(:xpath, 'ds:Reference') }
@@ -106,7 +107,7 @@ RSpec.shared_examples 'ds:Signature xml' do
 
     let(:c14n_signed_info) do
       doc = builder.doc.dup
-      doc.at_xpath("#{sig_xpath}/ds:SignedInfo")
+      doc.at_xpath("#{doc_sig_xpath}/ds:SignedInfo")
         .canonicalize(Nokogiri::XML::XML_C14N_EXCLUSIVE_1_0)
     end
 

--- a/spec/support/taggable.rb
+++ b/spec/support/taggable.rb
@@ -9,7 +9,7 @@ shared_examples 'a taggable model' do | tag_factory, association |
   end
 
   describe '#with_any_tag' do
-    let(:tag_name) { Faker::Lorem.characters }
+    let(:tag_name) { Faker::Lorem.word }
     let(:instance) { create(klass) }
 
     subject { described_class.with_any_tag(tag_name) }


### PR DESCRIPTION
**MDQP** defines a simple protocol for retrieving metadata about named entities, or named collections of entities.  The goal of the protocol is to profile various aspects of HTTP to allow requesters to
rely on certain, rigorously defined, behaviour.

The code contained within this PR implements:

1. https://github.com/iay/md-query/blob/master/draft-young-md-query.txt (draft-young-md-query-05)
1. https://github.com/iay/md-query/blob/master/draft-young-md-query-saml.txt (draft-young-md-query-saml-05)

Due to the requirements of MDQP and the state of saml-service implementation prior implementing MDQP the PR also addresses changes with DB structure and signature generation. In addition RawEntityDescriptor has much greater internal support including the ability to act as a single, signed, root node in response to metadata queries.

I believe all parts of these specs are covered in this PR, so anything which is 'missing' should be highlighted for correction prior to merge except for the following in md-query:

* 2.2 which can't be identified within the Rails stack (as best as my research indicates)
* 4.3
* 6.2/6.3

All of the above will be handled by the implementing Apache HTTPD instance.