### PR TITLE
Switch to redis cache

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -41,7 +41,7 @@ group :development, :test do
   gem 'rspec_sequel_matchers', git: 'https://github.com/bradleybeddoes/rspec_sequel_matchers.git'
   gem 'factory_girl_rails'
   gem 'faker'
-  gem 'fakeredis', require: 'fakeredis/rspec'
+  gem 'fakeredis', require: false
   gem 'capybara', '~> 2.4'
   gem 'timecop', '~> 0.7'
   gem 'webmock', require: false

--- a/Gemfile
+++ b/Gemfile
@@ -15,6 +15,7 @@ gem 'xmldsig'
 gem 'resque'
 gem 'resque-retry'
 gem 'redis'
+gem 'redis-rails'
 
 gem 'recursive-open-struct'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -212,8 +212,24 @@ GEM
       ffi (>= 0.5.0)
     recursive-open-struct (0.6.5)
     redis (3.2.1)
+    redis-actionpack (4.0.0)
+      actionpack (~> 4)
+      redis-rack (~> 1.5.0)
+      redis-store (~> 1.1.0)
+    redis-activesupport (4.1.1)
+      activesupport (~> 4)
+      redis-store (~> 1.1.0)
     redis-namespace (1.5.2)
       redis (~> 3.0, >= 3.0.4)
+    redis-rack (1.5.0)
+      rack (~> 1.5)
+      redis-store (~> 1.1.0)
+    redis-rails (4.0.0)
+      redis-actionpack (~> 4)
+      redis-activesupport (~> 4)
+      redis-store (~> 1.1.0)
+    redis-store (1.1.6)
+      redis (>= 2.2)
     ref (2.0.0)
     resque (1.25.2)
       mono_logger (~> 1.0)
@@ -347,6 +363,7 @@ DEPENDENCIES
   rails (~> 4.2)
   recursive-open-struct
   redis
+  redis-rails
   resque
   resque-retry
   rspec-rails (~> 3.1)

--- a/config/application.rb
+++ b/config/application.rb
@@ -22,5 +22,7 @@ module Saml
       Sequel::Model.plugin :timestamps, update_on_create: true
       Sequel::Model.plugin :validation_helpers
     end
+
+    config.cache_store = :redis_store, 'redis://localhost:6379/0/cache'
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,7 @@
 require 'simplecov'
 
 require 'webmock/rspec'
+require 'fakeredis/rspec'
 
 RSpec.configure do |config|
   config.filter_run :focus


### PR DESCRIPTION
File-based caching was causing some issues for clean checkouts of the project. Switching to redis-based caching will stop the need for manual creation of `tmp/cache`