### PR TITLE
Scope entity updates to the source in use

### DIFF
--- a/spec/factories/known_entities.rb
+++ b/spec/factories/known_entities.rb
@@ -1,6 +1,8 @@
 FactoryGirl.define do
   factory :known_entity do
-    transient { hostname { "e.#{Faker::Internet.domain_name}" } }
+    transient do
+      hostname { "e.#{Faker::Internet.domain_name}" }
+    end
 
     association :entity_source
     enabled true
@@ -15,7 +17,7 @@ FactoryGirl.define do
     trait :with_raw_entity_descriptor do
       after(:create) do |ke|
         red = create :raw_entity_descriptor, known_entity: ke
-        ke.entity_descriptor = red
+        ke.raw_entity_descriptor = red
       end
     end
   end

--- a/spec/jobs/update_entity_source_spec.rb
+++ b/spec/jobs/update_entity_source_spec.rb
@@ -72,6 +72,15 @@ RSpec.describe UpdateEntitySource do
     ].compact.join("\n")
   end
 
+  context 'with an invalid EntitySource ID' do
+    let(:xml) { entities_descriptor(entities: 1) }
+
+    it 'throws an exception' do
+      expect { described_class.perform(id: -1, primary_tag: Faker::Lorem.word) }
+        .to raise_error('Unable to locate EntitySource(id=-1)')
+    end
+  end
+
   context 'with a single entity' do
     let(:xml) { entities_descriptor(entities: 1) }
 
@@ -198,6 +207,51 @@ RSpec.describe UpdateEntitySource do
           Timecop.travel(1.second) do
             expect { run }
               .to change { red.reload.known_entity.updated_at }
+          end
+        end
+
+        context 'entity descriptor exists from a different source' do
+          let(:secondary_es) do
+            create(:entity_source, :external, certificate: certificate.to_pem)
+          end
+          let!(:additional_entity_reference) do
+            create :known_entity,
+                   :with_raw_entity_descriptor,
+                   entity_source: secondary_es, enabled: true
+          end
+
+          before do
+            additional_entity_reference.raw_entity_descriptor
+              .entity_id.update(uri: entity_id)
+          end
+
+          it 'results in two references for the same entity_id' do
+            expect(EntityId.where(uri: entity_id).count).to eq(2)
+          end
+
+          it 'has differing sources for each EntityId reference' do
+            es1 =
+              EntityId.where(uri: entity_id).first.parent
+              .known_entity.entity_source
+            es2 =
+              EntityId.where(uri: entity_id).last.parent
+              .known_entity.entity_source
+
+            expect(es1 == es2).to be_falsey
+          end
+
+          it 'updates the known_entity for this source' do
+            Timecop.travel(1.second) do
+              expect { run }
+                .to change { red.reload.known_entity.updated_at }
+            end
+          end
+
+          it 'does not update other known_entity instances' do
+            Timecop.travel(1.second) do
+              expect { run }
+                .not_to change { additional_entity_reference.reload.updated_at }
+            end
           end
         end
       end


### PR DESCRIPTION
This will prevent unintend change occuring when the same EntityId is
presented within multiple EntitySources.

Additionally this commit better protects the update job by throwing an
explicit exception should the provided id not reference a known
EntitySource.