### PR TITLE
Optimize DS API endpoint to respond correctly with a large dataset

### DIFF
--- a/app/controllers/api/discovery_entities_controller.rb
+++ b/app/controllers/api/discovery_entities_controller.rb
@@ -37,7 +37,18 @@ module API
       }
     )
 
-    private_constant :SP_EAGER_FETCH, :IDP_EAGER_FETCH
+    RAW_COMMON_EAGER_FETCH = {
+      entity_id: [],
+      known_entity: :tags
+    }
+
+    RAW_IDP_EAGER_FETCH = RAW_COMMON_EAGER_FETCH
+
+    RAW_SP_EAGER_FETCH = RAW_COMMON_EAGER_FETCH
+
+    private_constant :COMMON_EAGER_FETCH, :SP_EAGER_FETCH, :IDP_EAGER_FETCH,
+                     :RAW_COMMON_EAGER_FETCH, :RAW_IDP_EAGER_FETCH,
+                     :RAW_SP_EAGER_FETCH
 
     def ed_containing_sp
       entities_with_role_descriptor(:sp_sso_descriptors)
@@ -45,7 +56,8 @@ module API
     end
 
     def red_containing_sp
-      RawEntityDescriptor.where(sp: true).eager(known_entity: :tags).all
+      RawEntityDescriptor.where(sp: true).eager(known_entity: :tags)
+        .eager(RAW_SP_EAGER_FETCH).all
     end
 
     def ed_containing_idp
@@ -54,7 +66,8 @@ module API
     end
 
     def red_containing_idp
-      RawEntityDescriptor.where(idp: true).eager(known_entity: :tags).all
+      RawEntityDescriptor.where(idp: true).eager(known_entity: :tags)
+        .eager(RAW_IDP_EAGER_FETCH).all
     end
 
     def entities_with_role_descriptor(table)

--- a/app/models/concerns/raw_entity_descriptor_deconstructor.rb
+++ b/app/models/concerns/raw_entity_descriptor_deconstructor.rb
@@ -5,8 +5,8 @@ module RawEntityDescriptorDeconstructor
     ui_info_node = Nokogiri::XML.parse(xml).xpath(UI_INFO_PATH)
     return unless ui_info_node.present?
 
-    ui_info = OpenStruct.new(display_names: [], descriptions: [], logos: [],
-                             information_urls: [], privacy_statement_urls: [])
+    ui_info = os(display_names: [], descriptions: [], logos: [],
+                 information_urls: [], privacy_statement_urls: [])
 
     display_names(ui_info_node, ui_info)
     descriptions(ui_info_node, ui_info)
@@ -22,8 +22,7 @@ module RawEntityDescriptorDeconstructor
     disco_hints_node = doc.xpath(DISCO_HINTS_PATH)
     return unless disco_hints_node.present?
 
-    disco_hints = OpenStruct.new(ip_hints: [], domain_hints: [],
-                                 geolocation_hints: [])
+    disco_hints = os(ip_hints: [], domain_hints: [], geolocation_hints: [])
 
     ip_hints(disco_hints_node, disco_hints)
     domain_hints(disco_hints_node, disco_hints)
@@ -53,51 +52,51 @@ module RawEntityDescriptorDeconstructor
   def display_names(ui_info_node, ui_info)
     ui_info_node.xpath(UI_INFO_DISPLAY_NAME_PATH).each do |dn|
       ui_info.display_names <<
-        { lang: dn.attributes['lang'].value, value: dn.text.strip }
+        os(lang: dn.attributes['lang'].value, value: dn.text.strip)
     end
   end
 
   def descriptions(ui_info_node, ui_info)
     ui_info_node.xpath(UI_INFO_DESCRIPTION_PATH).each do |desc|
       ui_info.descriptions <<
-        { lang: desc.attributes['lang'].value, value: desc.text.strip }
+        os(lang: desc.attributes['lang'].value, value: desc.text.strip)
     end
   end
 
   def logos(ui_info_node, ui_info)
     ui_info_node.xpath(UI_INFO_LOGO_PATH).each do |logo|
       ui_info.logos <<
-        { width: logo.attributes['width'].value,
-          height: logo.attributes['height'].value,
-          uri: logo.text.strip }
+        os(width: logo.attributes['width'].value,
+           height: logo.attributes['height'].value,
+           uri: logo.text.strip)
     end
   end
 
   def information_urls(ui_info_node, ui_info)
     ui_info_node.xpath(UI_INFO_INFORMATION_URL_PATH).each do |inf|
       ui_info.information_urls <<
-        { lang: inf.attributes['lang'].value, uri: inf.text.strip }
+        os(lang: inf.attributes['lang'].value, uri: inf.text.strip)
     end
   end
 
   def privacy_statement_urls(ui_info_node, ui_info)
     ui_info_node.xpath(UI_INFO_PRIVACY_STATEMENT_URL_PATH).each do |ps|
       ui_info.privacy_statement_urls <<
-        { lang: ps.attributes['lang'].value, uri: ps.text.strip }
+        os(lang: ps.attributes['lang'].value, uri: ps.text.strip)
     end
   end
 
   def ip_hints(disco_hints_node, disco_hints)
     disco_hints_node.xpath(DISCO_HINTS_IP_HINT_PATH).each do |iph|
       disco_hints.ip_hints <<
-        { block: iph.text.strip }
+        os(block: iph.text.strip)
     end
   end
 
   def domain_hints(disco_hints_node, disco_hints)
     disco_hints_node.xpath(DISCO_HINTS_DOMAIN_HINT_PATH).each do |dh|
       disco_hints.domain_hints <<
-        { domain: dh.text.strip }
+        os(domain: dh.text.strip)
     end
   end
 
@@ -105,8 +104,8 @@ module RawEntityDescriptorDeconstructor
     disco_hints_node.xpath(DISCO_HINTS_GEOLOCATION_HINT_PATH).each do |glh|
       uri_parts = geolocation_parts(glh.text.strip)
       disco_hints.geolocation_hints <<
-        { latitude: uri_parts[0], longitude: uri_parts[1],
-          altitude: uri_parts[2] }
+        os(latitude: uri_parts[0], longitude: uri_parts[1],
+           altitude: uri_parts[2])
     end
   end
 
@@ -116,22 +115,28 @@ module RawEntityDescriptorDeconstructor
 
   def extract_discovery_response_services(discovery_response_node)
     discovery_response_node.map do |ds|
-      {
+      os(
         location: ds.attributes['Location'].value,
         binding: ds.attributes['Binding'].value,
         index: ds.attributes['index'].value,
         is_default: ds.attributes['isDefault'].value
-      }
+      )
     end
   end
 
   def extract_single_sign_on_services(single_sign_on_services_node)
     single_sign_on_services_node.map do |sso|
-      {
+      os(
         location: sso.attributes['Location'].value,
         binding: sso.attributes['Binding'].value
-      }
+      )
     end
+  end
+
+  private
+
+  def os(hash)
+    OpenStruct.new(hash)
   end
 
   class <<self

--- a/app/models/raw_entity_descriptor.rb
+++ b/app/models/raw_entity_descriptor.rb
@@ -18,10 +18,14 @@ class RawEntityDescriptor < Sequel::Model
   def validate
     super
     validates_presence [:known_entity, :xml, :created_at, :updated_at]
-    validates_unique :known_entity
     validates_presence :entity_id, allow_missing: new?
     # Any more than 16_777_215, the column type needs to be upgraded (again).
     validates_max_length 16_777_215, :xml
+
+    # The two remaining validations are very expensive and don't need to run
+    # when calling `functioning?` on an unmodified record.
+    return unless modified?
+    validates_unique :known_entity # Prevented by DB schema
     validate_xml
   end
 

--- a/spec/models/raw_entity_descriptor_spec.rb
+++ b/spec/models/raw_entity_descriptor_spec.rb
@@ -104,34 +104,34 @@ RSpec.describe RawEntityDescriptor do
 
     it 'populates MDUI DisplayNames' do
       expect(subject.ui_info.display_names).to be_present
-      expect(subject.ui_info.display_names).to all(have_key(:lang))
-        .and all(have_key(:value))
+      expect(subject.ui_info.display_names).to all(respond_to(:lang))
+        .and all(respond_to(:value))
     end
 
     it 'populates MDUI Description' do
       expect(subject.ui_info.descriptions).to be_present
-      expect(subject.ui_info.descriptions).to all(have_key(:lang))
-        .and all(have_key(:value))
+      expect(subject.ui_info.descriptions).to all(respond_to(:lang))
+        .and all(respond_to(:value))
     end
 
     it 'populates MDUI Logo' do
       expect(subject.ui_info.logos).to be_present
       expect(subject.ui_info.logos)
-        .to all(have_key(:width))
-        .and all(have_key(:height))
-        .and all(have_key(:uri))
+        .to all(respond_to(:width))
+        .and all(respond_to(:height))
+        .and all(respond_to(:uri))
     end
 
     it 'populates MDUI Information URL' do
       expect(subject.ui_info.information_urls).to be_present
-      expect(subject.ui_info.information_urls).to all(have_key(:lang))
-        .and all(have_key(:uri))
+      expect(subject.ui_info.information_urls).to all(respond_to(:lang))
+        .and all(respond_to(:uri))
     end
 
     it 'populates MDUI Privacy Statement URL' do
       expect(subject.ui_info.privacy_statement_urls).to be_present
-      expect(subject.ui_info.privacy_statement_urls).to all(have_key(:lang))
-        .and all(have_key(:uri))
+      expect(subject.ui_info.privacy_statement_urls).to all(respond_to(:lang))
+        .and all(respond_to(:uri))
     end
   end
 
@@ -144,20 +144,20 @@ RSpec.describe RawEntityDescriptor do
 
     it 'populates IPHints' do
       expect(subject.disco_hints.ip_hints).to be_present
-      expect(subject.disco_hints.ip_hints).to all(have_key(:block))
+      expect(subject.disco_hints.ip_hints).to all(respond_to(:block))
     end
 
     it 'populates DomainHints' do
       expect(subject.disco_hints.domain_hints).to be_present
-      expect(subject.disco_hints.domain_hints).to all(have_key(:domain))
+      expect(subject.disco_hints.domain_hints).to all(respond_to(:domain))
     end
 
     it 'populates GelocationHints' do
       expect(subject.disco_hints.geolocation_hints).to be_present
       expect(subject.disco_hints.geolocation_hints)
-        .to all(have_key(:latitude))
-        .and all(have_key(:longitude))
-        .and all(have_key(:altitude))
+        .to all(respond_to(:latitude))
+        .and all(respond_to(:longitude))
+        .and all(respond_to(:altitude))
     end
   end
 
@@ -167,10 +167,10 @@ RSpec.describe RawEntityDescriptor do
     it 'populates an array when discovery_response xml content present' do
       expect(subject.discovery_response_services).to be_present
       expect(subject.discovery_response_services)
-        .to all(have_key(:location))
-        .and all(have_key(:binding))
-        .and all(have_key(:index))
-        .and all(have_key(:is_default))
+        .to all(respond_to(:location))
+        .and all(respond_to(:binding))
+        .and all(respond_to(:index))
+        .and all(respond_to(:is_default))
     end
   end
 
@@ -180,8 +180,8 @@ RSpec.describe RawEntityDescriptor do
     it 'populates an array when single_sign_on_services xml content present' do
       expect(subject.single_sign_on_services).to be_present
       expect(subject.single_sign_on_services)
-        .to all(have_key(:location))
-        .and all(have_key(:binding))
+        .to all(respond_to(:location))
+        .and all(respond_to(:binding))
     end
   end
 end


### PR DESCRIPTION
There were a couple of speed issues, the most serious of which was that `RawEntityDescriptor#functioning?` was invoking validations, which in turn performed a full XML schema validation of the `<EntityDescriptor>` within.

After resolving the speed issues, a bug remained which required that deconstructed raw entity data be wrapped in `OpenStruct` before the response would render correctly.

My dataset, which attempts to mimic a more realistic workload for saml-service:

```ruby
[1] pry(main)> KnownEntity.count
=> 4690
[2] pry(main)> RawEntityDescriptor.where(idp: true).count
=> 2000
[3] pry(main)> RawEntityDescriptor.where(sp: true).count
=> 1000
[4] pry(main)> SPSSODescriptor.count
=> 400
[5] pry(main)> IDPSSODescriptor.count
=> 100
[6] pry(main)> AttributeAuthorityDescriptor.count
=> 140
```

After optimization the endpoint responds in approximately 9 seconds on my Mac:

```ruby
[1] pry(main)> require 'net/http'; require 'benchmark'; require 'json'
=> true
[2] pry(main)> json = nil; Benchmark.measure { json = Net::HTTP.get(URI.parse('http://localhost:8080/api/discovery/entities')); nil }
=> #<Benchmark::Tms:0x007fc6cd14ac30
 @cstime=0.0,
 @cutime=0.0,
 @label="",
 @real=8.458452203980414,
 @stime=0.0,
 @total=0.009999999999999953,
 @utime=0.009999999999999953>
[3] pry(main)> data = JSON.parse(json); nil
=> nil
[4] pry(main)> data['identity_providers'].count
=> 2100
[5] pry(main)> data['service_providers'].count
=> 1400
```