### PR TITLE
Allow for correct handling of xsd schema valid but geo uri invalid values

### DIFF
--- a/app/models/concerns/raw_entity_descriptor_deconstructor.rb
+++ b/app/models/concerns/raw_entity_descriptor_deconstructor.rb
@@ -104,7 +104,7 @@ module RawEntityDescriptorDeconstructor
     disco_hints_node.xpath(DISCO_HINTS_GEOLOCATION_HINT_PATH).each do |glh|
       uri = glh.text.strip
       next unless valid_geolocation_uri?(uri)
-      uri_parts = geolocation_parts(uri)
+      uri_parts = MDUI::GeolocationHint.parse_uri_into_parts(uri)
       disco_hints.geolocation_hints <<
         os(latitude: uri_parts[0], longitude: uri_parts[1],
            altitude: uri_parts[2])
@@ -116,11 +116,7 @@ module RawEntityDescriptorDeconstructor
   end
 
   def valid_geolocation_uri?(uri)
-    parsed_uri = URI.parse(uri)
-
-    parsed_uri.scheme == 'geo' &&
-      parsed_uri.opaque.present? &&
-      parsed_uri.opaque.include?(',')
+    MDUI::GeolocationHint.valid_uri?(uri)
   end
 
   def extract_discovery_response_services(discovery_response_node)

--- a/app/models/concerns/raw_entity_descriptor_deconstructor.rb
+++ b/app/models/concerns/raw_entity_descriptor_deconstructor.rb
@@ -102,7 +102,9 @@ module RawEntityDescriptorDeconstructor
 
   def geolocation_hints(disco_hints_node, disco_hints)
     disco_hints_node.xpath(DISCO_HINTS_GEOLOCATION_HINT_PATH).each do |glh|
-      uri_parts = geolocation_parts(glh.text.strip)
+      uri = glh.text.strip
+      next unless valid_geolocation_uri?(uri)
+      uri_parts = geolocation_parts(uri)
       disco_hints.geolocation_hints <<
         os(latitude: uri_parts[0], longitude: uri_parts[1],
            altitude: uri_parts[2])
@@ -111,6 +113,14 @@ module RawEntityDescriptorDeconstructor
 
   def geolocation_parts(uri)
     URI.parse(uri).opaque.split(',', 3)
+  end
+
+  def valid_geolocation_uri?(uri)
+    parsed_uri = URI.parse(uri)
+
+    parsed_uri.scheme == 'geo' &&
+      parsed_uri.opaque.present? &&
+      parsed_uri.opaque.include?(',')
   end
 
   def extract_discovery_response_services(discovery_response_node)

--- a/app/models/mdui/geolocation_hint.rb
+++ b/app/models/mdui/geolocation_hint.rb
@@ -19,10 +19,22 @@ module MDUI
       uri_parts[2]
     end
 
+    def self.parse_uri_into_parts(uri)
+      URI.parse(uri).opaque.partition(';').first.split(',', 3)
+    end
+
+    def self.valid_uri?(uri)
+      parsed_uri = URI.parse(uri)
+
+      parsed_uri.scheme == 'geo' &&
+        parsed_uri.opaque.present? &&
+        parsed_uri.opaque.include?(',')
+    end
+
     private
 
     def uri_parts
-      @uri_parts ||= URI.parse(uri).opaque.split(',', 3)
+      @uri_parts ||= MDUI::GeolocationHint.parse_uri_into_parts(uri)
     end
   end
 end

--- a/spec/factories/raw_entity_descriptors.rb
+++ b/spec/factories/raw_entity_descriptors.rb
@@ -142,5 +142,60 @@ FactoryGirl.define do
         EOF
       end
     end
+
+    factory :raw_entity_descriptor_invalid_geo_location do
+      transient do
+        hostname { "raw.#{Faker::Internet.domain_name}" }
+        entity_id_uri { "https://#{hostname}/shibboleth" }
+      end
+
+      enabled true
+
+      association :known_entity
+
+      xml do
+        <<-EOF.strip_heredoc
+          <EntityDescriptor xmlns="urn:oasis:names:tc:SAML:2.0:metadata"
+            xmlns:mdui="urn:oasis:names:tc:SAML:metadata:ui"
+            entityID="#{entity_id_uri}">
+            <Extensions>
+              <mdui:UIInfo>
+                <mdui:DisplayName xml:lang="en">
+                  #{Faker::Lorem.word}
+                </mdui:DisplayName>
+                <mdui:Description xml:lang="en">
+                  #{Faker::Lorem.sentence}
+                </mdui:Description>
+                <mdui:Logo height="16" width="16">
+                   https://example.edu/img.png
+               </mdui:Logo>
+               <mdui:InformationURL xml:lang="en">
+                  #{Faker::Internet.url}
+                </mdui:InformationURL>
+                <mdui:PrivacyStatementURL xml:lang="en">
+                  #{Faker::Internet.url}
+                </mdui:PrivacyStatementURL>
+              </mdui:UIInfo>
+              <mdui:DiscoHints>
+                <mdui:IPHint>2001:620::0/96</mdui:IPHint>
+                <mdui:DomainHint>example.edu</mdui:DomainHint>
+                <mdui:GeolocationHint>
+                  geo:47.37328,8.531126
+                </mdui:GeolocationHint>
+                <mdui:GeolocationHint>
+                  http://invalid.example.com
+                </mdui:GeolocationHint>
+              </mdui:DiscoHints>
+            </Extensions>
+            <AttributeAuthorityDescriptor
+              protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol">
+              <AttributeService
+                Binding="urn:oasis:names:tc:SAML:2.0:bindings:SOAP"
+                Location="https://#{hostname}/idp/profile/AttributeQuery/SOAP"/>
+            </AttributeAuthorityDescriptor>
+          </EntityDescriptor>
+        EOF
+      end
+    end
   end
 end

--- a/spec/models/mdui/geolocation_hint_spec.rb
+++ b/spec/models/mdui/geolocation_hint_spec.rb
@@ -43,4 +43,87 @@ RSpec.describe MDUI::GeolocationHint, type: :model do
       end
     end
   end
+
+  describe '#valid_uri?' do
+    let(:lat) { Faker::Number.decimal(5) }
+    let(:long) { Faker::Number.decimal(5) }
+    let(:alt) { Faker::Number.decimal(2) }
+
+    context 'valid uri values' do
+      it 'minimal uri' do
+        uri = "geo:#{lat},#{long}"
+        expect(MDUI::GeolocationHint.valid_uri?(uri)).to be_truthy
+      end
+
+      it 'extended uri' do
+        uri = "geo:#{lat},#{long},#{alt}"
+        expect(MDUI::GeolocationHint.valid_uri?(uri)).to be_truthy
+      end
+
+      it 'with parameters' do
+        uri = "geo:#{lat},#{long},#{alt};u=35"
+        expect(MDUI::GeolocationHint.valid_uri?(uri)).to be_truthy
+      end
+    end
+
+    context 'invalid uri' do
+      it 'no geo scheme' do
+        uri = "xyz:#{lat},#{long}"
+        expect(MDUI::GeolocationHint.valid_uri?(uri)).to be_falsey
+      end
+
+      it 'no opaque component' do
+        uri = 'geo:'
+        expect(MDUI::GeolocationHint.valid_uri?(uri)).to be_falsey
+      end
+
+      it 'values are not comma seperated' do
+        uri = "geo:#{lat}:#{long}"
+        expect(MDUI::GeolocationHint.valid_uri?(uri)).to be_falsey
+      end
+    end
+  end
+
+  describe '#parse_uri_into_parts' do
+    let(:lat) { Faker::Number.decimal(5) }
+    let(:long) { Faker::Number.decimal(5) }
+    let(:alt) { Faker::Number.decimal(2) }
+    let(:parsed_uri) { MDUI::GeolocationHint.parse_uri_into_parts(uri) }
+
+    shared_examples 'provides minimal values correctly' do
+      it 'provides expected values' do
+        expect(parsed_uri[0]).to eq(lat)
+        expect(parsed_uri[1]).to eq(long)
+        expect(parsed_uri[2]).to be_nil
+      end
+    end
+
+    shared_examples 'provides extended values correctly' do
+      it 'provides expected values including altitude' do
+        expect(parsed_uri[0]).to eq(lat)
+        expect(parsed_uri[1]).to eq(long)
+        expect(parsed_uri[2]).to eq(alt)
+      end
+    end
+
+    context 'with lat and long' do
+      let(:uri) { "geo:#{lat},#{long}" }
+      include_examples 'provides minimal values correctly'
+
+      context 'with additional parameters' do
+        let(:uri) { "geo:#{lat},#{long};u=#{Faker::Number.number(2)}" }
+        include_examples 'provides minimal values correctly'
+      end
+    end
+
+    context 'with lat, long and alt' do
+      let(:uri) { "geo:#{lat},#{long},#{alt}" }
+      include_examples 'provides extended values correctly'
+
+      context 'with additional parameters' do
+        let(:uri) { "geo:#{lat},#{long},#{alt};u=#{Faker::Number.number(2)}" }
+        include_examples 'provides extended values correctly'
+      end
+    end
+  end
 end

--- a/spec/models/raw_entity_descriptor_spec.rb
+++ b/spec/models/raw_entity_descriptor_spec.rb
@@ -159,9 +159,17 @@ RSpec.describe RawEntityDescriptor do
         .and all(respond_to(:longitude))
         .and all(respond_to(:altitude))
     end
+
+    context 'with invalid geolocation uri' do
+      subject { create :raw_entity_descriptor_invalid_geo_location }
+
+      it 'ignores invalid geolocation URI values' do
+        expect(subject.disco_hints.geolocation_hints.size).to eq(1)
+      end
+    end
   end
 
-  describe '#disco_hints' do
+  describe '#discovery_response_services' do
     subject { create :raw_entity_descriptor_sp }
 
     it 'populates an array when discovery_response xml content present' do


### PR DESCRIPTION
It seems eduGAIN sources have geolocation URI values that do not quite meet the underpinning specification. It was assumed this would be the case and code was developed to that.

This PR corrects our assumption of what will come from upstream, ensuring that 'invalid' URI are discounted.

This will correct a current fault within the test federation relating to DS API query.