### PR TITLE
Capture geo uri parse exceptions

### DIFF
--- a/app/models/mdui/geolocation_hint.rb
+++ b/app/models/mdui/geolocation_hint.rb
@@ -24,11 +24,15 @@ module MDUI
     end
 
     def self.valid_uri?(uri)
-      parsed_uri = URI.parse(uri)
+      begin
+        parsed_uri = URI.parse(uri)
 
-      parsed_uri.scheme == 'geo' &&
-        parsed_uri.opaque.present? &&
-        parsed_uri.opaque.include?(',')
+        parsed_uri.scheme == 'geo' &&
+          parsed_uri.opaque.present? &&
+          parsed_uri.opaque.include?(',')
+      rescue URI::InvalidURIError => e
+        false
+      end
     end
 
     private

--- a/app/models/mdui/geolocation_hint.rb
+++ b/app/models/mdui/geolocation_hint.rb
@@ -24,15 +24,13 @@ module MDUI
     end
 
     def self.valid_uri?(uri)
-      begin
-        parsed_uri = URI.parse(uri)
+      parsed_uri = URI.parse(uri)
 
-        parsed_uri.scheme == 'geo' &&
-          parsed_uri.opaque.present? &&
-          parsed_uri.opaque.include?(',')
-      rescue URI::InvalidURIError => e
-        false
-      end
+      parsed_uri.scheme == 'geo' &&
+        parsed_uri.opaque.present? &&
+        parsed_uri.opaque.include?(',')
+    rescue URI::InvalidURIError
+      false
     end
 
     private

--- a/spec/models/mdui/geolocation_hint_spec.rb
+++ b/spec/models/mdui/geolocation_hint_spec.rb
@@ -67,6 +67,11 @@ RSpec.describe MDUI::GeolocationHint, type: :model do
     end
 
     context 'invalid uri' do
+      it 'not a URI' do
+        uri = "xyz:#{lat}, #{long}" # space is invalid
+        expect(MDUI::GeolocationHint.valid_uri?(uri)).to be_falsey
+      end
+
       it 'no geo scheme' do
         uri = "xyz:#{lat},#{long}"
         expect(MDUI::GeolocationHint.valid_uri?(uri)).to be_falsey


### PR DESCRIPTION
Previously this state resulted in an exception going up the stack.

Lets be explicit and return false instead.