### PR TITLE
Ensure SAML metadata namespace is always xmlns default prefix

### DIFF
--- a/spec/factories/raw_entity_descriptors.rb
+++ b/spec/factories/raw_entity_descriptors.rb
@@ -197,5 +197,60 @@ FactoryGirl.define do
         EOF
       end
     end
+
+    factory :raw_entity_descriptor_xyz_namespaced do
+      transient do
+        hostname { "raw.#{Faker::Internet.domain_name}" }
+        entity_id_uri { "https://#{hostname}/shibboleth" }
+      end
+
+      enabled true
+
+      association :known_entity
+
+      xml do
+        <<-EOF.strip_heredoc
+          <xyz:EntityDescriptor xmlns:xyz="urn:oasis:names:tc:SAML:2.0:metadata"
+            xmlns:mdui="urn:oasis:names:tc:SAML:metadata:ui"
+            entityID="#{entity_id_uri}">
+            <xyz:Extensions>
+              <mdui:UIInfo>
+                <mdui:DisplayName xml:lang="en">
+                  #{Faker::Lorem.word}
+                </mdui:DisplayName>
+                <mdui:Description xml:lang="en">
+                  #{Faker::Lorem.sentence}
+                </mdui:Description>
+                <mdui:Logo height="16" width="16">
+                   https://example.edu/img.png
+               </mdui:Logo>
+               <mdui:InformationURL xml:lang="en">
+                  #{Faker::Internet.url}
+                </mdui:InformationURL>
+                <mdui:PrivacyStatementURL xml:lang="en">
+                  #{Faker::Internet.url}
+                </mdui:PrivacyStatementURL>
+              </mdui:UIInfo>
+              <mdui:DiscoHints>
+                <mdui:IPHint>2001:620::0/96</mdui:IPHint>
+                <mdui:DomainHint>example.edu</mdui:DomainHint>
+                <mdui:GeolocationHint>
+                  geo:47.37328,8.531126
+                </mdui:GeolocationHint>
+                <mdui:GeolocationHint>
+                  http://invalid.example.com
+                </mdui:GeolocationHint>
+              </mdui:DiscoHints>
+            </xyz:Extensions>
+            <xyz:AttributeAuthorityDescriptor
+              protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol">
+              <xyz:AttributeService
+                Binding="urn:oasis:names:tc:SAML:2.0:bindings:SOAP"
+                Location="https://#{hostname}/idp/profile/AttributeQuery/SOAP"/>
+            </xyz:AttributeAuthorityDescriptor>
+          </xyz:EntityDescriptor>
+        EOF
+      end
+    end
   end
 end

--- a/spec/jobs/update_entity_source_spec.rb
+++ b/spec/jobs/update_entity_source_spec.rb
@@ -411,12 +411,11 @@ RSpec.describe UpdateEntitySource do
         'xmlns:xyz="urn:oasis:names:tc:SAML:2.0:metadata" ',
         'ID="_x">',
         EMPTY_SIGNATURE.indent(2),
-        nil,
         entity_descriptors(entities: 1,
                            type: :raw_entity_descriptor_xyz_namespaced)
           .indent(2),
         '</xyz:EntitiesDescriptor>'
-      ].compact.join("\n")
+      ].join("\n")
     end
 
     let(:entity_id) { entity_ids.first }


### PR DESCRIPTION
Previously remote sources of metadata had their own ideas about
scoping for the uri 'urn:oasis:names:tc:SAML:2.0:metadata'.

Internally we expect this to be the default prefix for xmlns but other
sources, especially eduGAIN scope this to the prefix 'xmlns:md'.

On ingest we now correct source XML so it adheres to our world view,
which allows us to publish seemlessly a mix of internally and
externally sourced entities.

For +131 lines this was stupidly hard :sob: 