### PR TITLE
Extend socket timeout for http connections

### DIFF
--- a/app/jobs/concerns/query_federation_registry.rb
+++ b/app/jobs/concerns/query_federation_registry.rb
@@ -53,6 +53,7 @@ module QueryFederationRegistry
 
     http = Net::HTTP.new(url.host, url.port)
     http.use_ssl = (url.scheme == 'https')
+    http.read_timeout = 600
     http.request(request)
   end
 end

--- a/app/jobs/update_entity_source.rb
+++ b/app/jobs/update_entity_source.rb
@@ -46,12 +46,22 @@ class UpdateEntitySource
   end
 
   def retrieve(source)
-    parsed_url = URI.parse(source.url)
-    response = Net::HTTP.get_response(parsed_url)
+    url = URI.parse(source.url)
+    response = perform_http_client_request(url)
+
     return response.body if response.is_a?(Net::HTTPSuccess)
 
     fail("Unable to update EntitySource(id=#{source.id} url=#{source.url}). " \
          "Response was: #{response.code} #{response.message}")
+  end
+
+  def perform_http_client_request(url)
+    request = Net::HTTP::Get.new(url)
+    http = Net::HTTP.new(url.host, url.port)
+    http.use_ssl = (url.scheme == 'https')
+    http.read_timeout = 600
+
+    http.request(request)
   end
 
   def document(source)


### PR DESCRIPTION
As most of our outbound connections are either to dynamic sources
or remote international sources we occasionally tripped over the 60s
socket timeout.

This extends the timeout to 10 minutes which should see us complete
successfully during periods of instability.