### PR TITLE
Update request timeout to 10 minutes

### DIFF
--- a/config/unicorn.rb
+++ b/config/unicorn.rb
@@ -6,7 +6,7 @@ pid File.join(ROOT, 'tmp', 'pids', 'unicorn.pid')
 stdout_path '/var/log/aaf/saml/unicorn/stdout.log'
 stderr_path '/var/log/aaf/saml/unicorn/stderr.log'
 
-timeout 240
+timeout 600
 
 before_fork do |server, _worker|
   Sequel::Model.db.disconnect


### PR DESCRIPTION
Under load (generally relating to something upstream like the DB
cluster being pegged by a 3rd party service), valid but long running
queries can be timed out before practical.

This will allow us to continue to respond in these situations without
being hard terminated, albeit slowly.