### PR TITLE
Refine approach for DB pools before/after fork

### DIFF
--- a/config/unicorn.rb
+++ b/config/unicorn.rb
@@ -11,7 +11,7 @@ timeout 600
 before_fork do |server, _worker|
   # Ensure we don't keep connections
   Sequel::Model.db.disconnect
-  Sequel::DATABASES.each{|db| db.disconnect }
+  Sequel::DATABASES.each(&:disconnect)
 
   old_pid = File.join(ROOT, 'tmp', 'pids', 'unicorn.pid.oldbin')
   if File.exist?(old_pid) && server.pid != old_pid
@@ -23,7 +23,7 @@ before_fork do |server, _worker|
   end
 end
 
-after_fork do |server, worker|
+after_fork do |_server, _worker|
   SequelRails.setup Rails.env
 end
 


### PR DESCRIPTION
After looking into the nature of #80 this is an initial attempt at
resolving the error state by ensuring that pools for workers are
robustly established when unicorn forks.

This is not necessarily considered to be an absolute fix but will
provide further insight to the fault in terms of diagnosis.