### PR TITLE
Ensure MDUI descriptions are valid

### DIFF
--- a/app/jobs/concerns/etl/role_descriptors.rb
+++ b/app/jobs/concerns/etl/role_descriptors.rb
@@ -91,7 +91,7 @@ module ETL
 
       ui_info.add_display_name(MDUI::DisplayName.new(value: display_name,
                                                      lang: 'en'))
-      ui_info.add_description(MDUI::Description.new(value: description,
+      ui_info.add_description(MDUI::Description.new(value: description.squish,
                                                     lang: 'en'))
     end
 

--- a/spec/support/jobs/concerns/etl/common.rb
+++ b/spec/support/jobs/concerns/etl/common.rb
@@ -81,6 +81,10 @@ RSpec.shared_examples 'ETL::Common' do
   end
   # rubocop:enable Metrics/MethodLength
 
+  def description
+    @description ||= "#{Faker::Lorem.sentence}\r\n\t#{Faker::Lorem.sentence}"
+  end
+
   let(:scope) { 'example.edu' }
 
   let(:contact_instances) do
@@ -152,6 +156,12 @@ RSpec.shared_examples 'ETL::Common' do
 
     it 'updates mdui descriptions' do
       expect { run }.to change { subject.reload.ui_info.descriptions }
+    end
+
+    it 'squishes incoming description' do
+      run
+      expect(subject.reload.ui_info.descriptions.first.value)
+        .to eq(description.squish)
     end
   end
 

--- a/spec/support/jobs/concerns/etl/identity_providers.rb
+++ b/spec/support/jobs/concerns/etl/identity_providers.rb
@@ -6,7 +6,7 @@ RSpec.shared_examples 'ETL::IdentityProviders' do
     {
       id: idp.id,
       display_name: Faker::Lorem.sentence,
-      description: Faker::Lorem.sentence,
+      description: description,
       attribute_authority_only: false,
       functioning: idp.functioning?,
       created_at: idp_created_at,

--- a/spec/support/jobs/concerns/etl/service_providers.rb
+++ b/spec/support/jobs/concerns/etl/service_providers.rb
@@ -6,7 +6,7 @@ RSpec.shared_examples 'ETL::ServiceProviders' do
     {
       id: sp.id,
       display_name: Faker::Lorem.sentence,
-      description: Faker::Lorem.sentence,
+      description: description,
       functioning: sp.functioning?,
       created_at: sp_created_at,
       saml: {


### PR DESCRIPTION
In production we discovered an issue where data from FR
for MDUI descriptions contained the encoded value &#13;
due, we believe, to folks pasting into the multi-line
description field from word docs.

This in itself did not pose a problem but the Shibboleth SP
does not correctly handle this case when writing out backup
files thus signature validation would fail when the SP tried
to restart when upstream was not modified.