### PR TITLE
Update RawEntityDescriptor API endpoint to handle update *and* create 

### DIFF
--- a/app/controllers/api/raw_entity_descriptors_controller.rb
+++ b/app/controllers/api/raw_entity_descriptors_controller.rb
@@ -20,19 +20,6 @@ module API
 
     private
 
-    def update_raw_entity_descriptor
-      red = existing_entity_id.raw_entity_descriptor
-      red.xml = patch_params[:xml]
-      red.enabled = patch_params[:enabled]
-      ke = red.known_entity
-      ke.enabled = patch_params[:enabled]
-      Sequel::Model.db.transaction(isolation: :repeatable) do
-        red.save
-        ke.save
-        tag_known_entity(ke)
-      end
-    end
-
     def create_raw_entity_descriptor
       Sequel::Model.db.transaction(isolation: :repeatable) do
         ke = KnownEntity.create(entity_source: @entity_source,
@@ -42,6 +29,16 @@ module API
                       enabled: patch_params[:enabled], idp: true, sp: false)
         EntityId.create(uri: entity_id_uri,
                         raw_entity_descriptor: red)
+        tag_known_entity(ke)
+      end
+    end
+
+    def update_raw_entity_descriptor
+      red = existing_entity_id.raw_entity_descriptor
+      ke = red.known_entity
+      Sequel::Model.db.transaction(isolation: :repeatable) do
+        red.update(xml: patch_params[:xml], enabled: patch_params[:enabled])
+        ke.update(enabled: patch_params[:enabled])
         tag_known_entity(ke)
       end
     end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -31,9 +31,10 @@ Rails.application.routes.draw do
       scope 'discovery' do
         resources :discovery_entities, path: 'entities'
       end
-      post 'entity_sources/:tag/raw_entity_descriptors',
-           to: 'raw_entity_descriptors#create',
-           as: 'raw_entity_descriptors'
+      patch 'entity_sources/:tag/raw_entity_descriptors/'\
+            ':base64_urlsafe_entity_id',
+            to: 'raw_entity_descriptors#update',
+            as: 'raw_entity_descriptors'
     end
   end
 end

--- a/spec/controllers/api/raw_entity_descriptors_controller_spec.rb
+++ b/spec/controllers/api/raw_entity_descriptors_controller_spec.rb
@@ -2,13 +2,14 @@
 require 'rails_helper'
 
 RSpec.describe API::RawEntityDescriptorsController, type: :controller do
-  describe 'post :create' do
+  describe 'patch :update' do
     let(:entity_source) { create(:entity_source) }
     let(:source_tag) { entity_source.source_tag }
 
     let(:tags) { [Faker::Lorem.word, Faker::Lorem.word] }
     let(:host_name) { Faker::Internet.domain_name }
     let(:entity_id) { "https://#{host_name}/shibboleth" }
+    let(:base64_urlsafe_entity_id) { Base64.urlsafe_encode64(entity_id) }
     let(:enabled) { [true, false].sample }
     let(:xml) do
       <<-EOF.strip_heredoc
@@ -25,17 +26,16 @@ RSpec.describe API::RawEntityDescriptorsController, type: :controller do
         EOF
     end
 
-    let(:raw_entity_descriptor) do
-      { xml: xml, tags: tags, entity_id: entity_id, enabled: enabled }
-    end
+    let(:raw_entity_descriptor) { { xml: xml, tags: tags, enabled: enabled } }
 
     def run
       if api_subject
         request.env['HTTP_X509_DN'] = "CN=#{api_subject.x509_cn}".dup
       end
 
-      post :create, tag: source_tag,
-                    raw_entity_descriptor: raw_entity_descriptor
+      patch :update, tag: source_tag,
+                     base64_urlsafe_entity_id: base64_urlsafe_entity_id,
+                     raw_entity_descriptor: raw_entity_descriptor
     end
 
     def swallow
@@ -68,7 +68,7 @@ RSpec.describe API::RawEntityDescriptorsController, type: :controller do
         it { is_expected.to have_http_status(:not_found) }
       end
 
-      context 'with valid params' do
+      context 'when the raw entity descriptor does not exist' do
         it { is_expected.to have_http_status(:created) }
 
         context 'raw entity descriptors' do
@@ -183,6 +183,179 @@ RSpec.describe API::RawEntityDescriptorsController, type: :controller do
         end
       end
 
+      context 'when the raw entity descriptor exists' do
+        let(:original_tags) { [Faker::Lorem.word, Faker::Lorem.word] }
+        let(:original_host_name) { Faker::Internet.domain_name }
+        let(:original_enabled) { [true, false].sample }
+        let(:original_xml) do
+          <<-EOF.strip_heredoc
+            <EntityDescriptor xmlns="urn:oasis:names:tc:SAML:2.0:metadata"
+              xmlns:mdui="urn:oasis:names:tc:SAML:metadata:ui"
+              entityID="#{entity_id}">
+              <IDPSSODescriptor
+             protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol">
+                <SingleSignOnService
+                  Binding="urn:oasis:names:tc:SAML:2.0:bindings:SOAP"
+       Location="https://#{original_host_name}/idp/profile/SAML2/Redirect/SSO"/>
+              </IDPSSODescriptor>
+            </EntityDescriptor>
+          EOF
+        end
+
+        let(:original_known_entity) do
+          create(:known_entity, entity_source: entity_source,
+                                enabled: original_enabled)
+        end
+
+        let(:original_raw_entity_descriptor) do
+          create(:raw_entity_descriptor, known_entity: original_known_entity,
+                                         xml: original_xml, idp: true)
+        end
+
+        before do
+          EntityId.create(uri: entity_id,
+                          raw_entity_descriptor: original_raw_entity_descriptor)
+          original_tags.each { |t| original_known_entity.tag_as(t) }
+        end
+
+        it { is_expected.to have_http_status(:no_content) }
+
+        context 'raw entity descriptors' do
+          subject { -> { run } }
+          it { is_expected.to_not change(RawEntityDescriptor, :count) }
+
+          context 'record' do
+            before { run }
+            let(:record) { RawEntityDescriptor.last }
+
+            subject { record }
+
+            context 'xml' do
+              subject { record.xml }
+
+              it 'has been updated' do
+                expect(subject).to eq(xml)
+              end
+            end
+
+            context 'enabled' do
+              subject { record.enabled }
+
+              it 'has been updated' do
+                expect(subject).to eq(enabled)
+              end
+            end
+
+            context 'idp' do
+              subject { record.idp }
+              it { is_expected.to be_truthy }
+            end
+
+            context 'sp' do
+              subject { record.sp }
+              it { is_expected.to be_falsey }
+            end
+
+            context 'standalone aa' do
+              subject { record.standalone_aa }
+              it { is_expected.to be_falsey }
+            end
+          end
+        end
+
+        context 'known entity' do
+          subject { -> { run } }
+          it { is_expected.to_not change(KnownEntity, :count) }
+
+          context 'record' do
+            before { run }
+            let(:record) { KnownEntity.last }
+            subject { record }
+
+            context 'enabled' do
+              subject { record.enabled }
+
+              it 'has been updated' do
+                expect(subject).to eq(enabled)
+              end
+            end
+
+            context 'entity source' do
+              let(:entity_source_record) { record.entity_source }
+
+              context 'id' do
+                subject { entity_source_record.id }
+                it 'has not changed' do
+                  expect(subject).to eq(entity_source.id)
+                end
+              end
+            end
+
+            context 'tags' do
+              subject { record.tags.map(&:name) }
+              let(:new_tags) { tags.append(source_tag) }
+              let(:all_tags) { new_tags + original_tags }
+
+              it 'appends the new tags' do
+                expect(subject).to contain_exactly(*all_tags)
+              end
+            end
+          end
+        end
+
+        context 'entity id' do
+          subject { -> { run } }
+          it { is_expected.to_not change(EntityId, :count) }
+
+          context 'record' do
+            before { run }
+            let(:record) { EntityId.last }
+            subject { record }
+
+            context 'uri' do
+              subject { record.uri }
+
+              it 'has not changed' do
+                expect(subject).to eq(entity_id)
+              end
+            end
+
+            context 'description' do
+              subject { record.description }
+              it { is_expected.to be_nil }
+            end
+
+            context 'role descriptor id' do
+              subject { record.role_descriptor_id }
+              it { is_expected.to be_nil }
+            end
+
+            context 'entity descriptor' do
+              subject { record.entity_descriptor }
+              it { is_expected.to be_nil }
+            end
+
+            context 'raw entity descriptor' do
+              let(:raw_entity_descriptor_record) do
+                record.raw_entity_descriptor
+              end
+
+              context 'id' do
+                subject { raw_entity_descriptor_record.id }
+                it 'has not changed' do
+                  expect(subject).to eq(original_raw_entity_descriptor.id)
+                end
+              end
+            end
+
+            context 'sha1' do
+              subject { record.sha1 }
+              it { is_expected.to eq(Digest::SHA1.hexdigest(entity_id)) }
+            end
+          end
+        end
+      end
+
       RSpec.shared_examples 'no state changed' do
         subject { -> { swallow { run } } }
 
@@ -216,12 +389,12 @@ RSpec.describe API::RawEntityDescriptorsController, type: :controller do
         it_behaves_like 'no state changed'
       end
 
-      context 'with a missing entity id' do
-        before { raw_entity_descriptor.delete(:entity_id) }
+      context 'with an invalid base64 urlsafe entity id' do
+        let(:base64_urlsafe_entity_id) { Faker::Lorem.sentence }
         subject { -> { run } }
-        let(:message) { /uri is not present/ }
+        let(:message) { /invalid base64/ }
 
-        it { is_expected.to raise_error(Sequel::ValidationFailed, message) }
+        it { is_expected.to raise_error(ArgumentError, message) }
         it_behaves_like 'no state changed'
       end
 
@@ -247,7 +420,7 @@ RSpec.describe API::RawEntityDescriptorsController, type: :controller do
       end
 
       context 'with invalid entity id' do
-        let(:entity_id) { Faker::Lorem.characters }
+        let(:entity_id) { SecureRandom.urlsafe_base64 }
         subject { -> { run } }
         let(:message) { /uri is not a valid uri/ }
 

--- a/spec/controllers/api/raw_entity_descriptors_controller_spec.rb
+++ b/spec/controllers/api/raw_entity_descriptors_controller_spec.rb
@@ -8,14 +8,14 @@ RSpec.describe API::RawEntityDescriptorsController, type: :controller do
 
     let(:tags) { [Faker::Lorem.word, Faker::Lorem.word] }
     let(:host_name) { Faker::Internet.domain_name }
-    let(:entity_id) { "https://#{host_name}/shibboleth" }
-    let(:base64_urlsafe_entity_id) { Base64.urlsafe_encode64(entity_id) }
+    let(:entity_id_uri) { "https://#{host_name}/shibboleth" }
+    let(:base64_urlsafe_entity_id) { Base64.urlsafe_encode64(entity_id_uri) }
     let(:enabled) { [true, false].sample }
     let(:xml) do
       <<-EOF.strip_heredoc
           <EntityDescriptor xmlns="urn:oasis:names:tc:SAML:2.0:metadata"
             xmlns:mdui="urn:oasis:names:tc:SAML:metadata:ui"
-            entityID="#{entity_id}">
+            entityID="#{entity_id_uri}">
             <IDPSSODescriptor
               protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol">
               <SingleSignOnService
@@ -152,7 +152,7 @@ RSpec.describe API::RawEntityDescriptorsController, type: :controller do
 
             context 'uri' do
               subject { record.uri }
-              it { is_expected.to eq(entity_id) }
+              it { is_expected.to eq(entity_id_uri) }
             end
 
             context 'description' do
@@ -177,7 +177,7 @@ RSpec.describe API::RawEntityDescriptorsController, type: :controller do
 
             context 'sha1' do
               subject { record.sha1 }
-              it { is_expected.to eq(Digest::SHA1.hexdigest(entity_id)) }
+              it { is_expected.to eq(Digest::SHA1.hexdigest(entity_id_uri)) }
             end
           end
         end
@@ -191,7 +191,7 @@ RSpec.describe API::RawEntityDescriptorsController, type: :controller do
           <<-EOF.strip_heredoc
             <EntityDescriptor xmlns="urn:oasis:names:tc:SAML:2.0:metadata"
               xmlns:mdui="urn:oasis:names:tc:SAML:metadata:ui"
-              entityID="#{entity_id}">
+              entityID="#{entity_id_uri}">
               <IDPSSODescriptor
              protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol">
                 <SingleSignOnService
@@ -213,7 +213,7 @@ RSpec.describe API::RawEntityDescriptorsController, type: :controller do
         end
 
         before do
-          EntityId.create(uri: entity_id,
+          EntityId.create(uri: entity_id_uri,
                           raw_entity_descriptor: original_raw_entity_descriptor)
           original_tags.each { |t| original_known_entity.tag_as(t) }
         end
@@ -316,7 +316,7 @@ RSpec.describe API::RawEntityDescriptorsController, type: :controller do
               subject { record.uri }
 
               it 'has not changed' do
-                expect(subject).to eq(entity_id)
+                expect(subject).to eq(entity_id_uri)
               end
             end
 
@@ -350,7 +350,7 @@ RSpec.describe API::RawEntityDescriptorsController, type: :controller do
 
             context 'sha1' do
               subject { record.sha1 }
-              it { is_expected.to eq(Digest::SHA1.hexdigest(entity_id)) }
+              it { is_expected.to eq(Digest::SHA1.hexdigest(entity_id_uri)) }
             end
           end
         end
@@ -419,8 +419,8 @@ RSpec.describe API::RawEntityDescriptorsController, type: :controller do
         it_behaves_like 'no state changed'
       end
 
-      context 'with invalid entity id' do
-        let(:entity_id) { SecureRandom.urlsafe_base64 }
+      context 'with invalid entity id uri' do
+        let(:entity_id_uri) { SecureRandom.urlsafe_base64 }
         subject { -> { run } }
         let(:message) { /uri is not a valid uri/ }
 

--- a/spec/routes/raw_entity_descriptors_routing_spec.rb
+++ b/spec/routes/raw_entity_descriptors_routing_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe API::RawEntityDescriptorsController, type: :routing do
+  let(:entity_source) { create(:entity_source) }
+  let(:source_tag) { entity_source.source_tag }
+  let(:entity_id) { Faker::Internet.url }
+  let(:base64_urlsafe_entity_id) { Base64.urlsafe_encode64(entity_id) }
+
+  it 'routes patch /api/entity_sources/:tag/raw_entity_descriptors'\
+      '/:base64_urlsafe_entity_id to #update' do
+    expect(patch("/api/entity_sources/#{source_tag}/raw_entity_descriptors/"\
+             "#{base64_urlsafe_entity_id}"))
+      .to route_to(
+        controller: 'api/raw_entity_descriptors',
+        action: 'update',
+        tag: source_tag,
+        base64_urlsafe_entity_id: base64_urlsafe_entity_id,
+        format: 'json'
+      )
+  end
+end


### PR DESCRIPTION
**Edit:**
Originally this was a `POST` endpoint which only supported **creating** RawEntityDescriptors. Now that we can guarantee uniqueness (tag + EntityId), we can use the EntityId to update *and* create RawEntityDescriptors.

---
Update API interface as outlined here: https://gist.github.com/rianniello/8eebbefb7dbf9e894397c43edf0709e5. 

Branched from https://github.com/ausaccessfed/saml-service/pull/127, which needs to be merged first.
