### PR TITLE
Infer SAML entity type from raw XML

### DIFF
--- a/app/jobs/concerns/set_saml_type_from_xml.rb
+++ b/app/jobs/concerns/set_saml_type_from_xml.rb
@@ -1,58 +1,61 @@
 # frozen_string_literal: true
 module SetSAMLTypeFromXML
-  ENTITY_DESCRIPTOR_XPATH =
-    '//*[local-name() = "EntityDescriptor" and ' \
+  def self.xpath_for_metadata_element(name)
+    "//*[local-name() = \"#{name}\" and " \
     'namespace-uri() = "urn:oasis:names:tc:SAML:2.0:metadata"]'
+  end
 
-  private_constant :ENTITY_DESCRIPTOR_XPATH
-
-  IDP_SSO_DESCRIPTOR_XPATH =
-    '//*[local-name() = "IDPSSODescriptor" and ' \
-    'namespace-uri() = "urn:oasis:names:tc:SAML:2.0:metadata"]'
-
-  private_constant :IDP_SSO_DESCRIPTOR_XPATH
-
+  ENTITY_DESCRIPTOR_XPATH = xpath_for_metadata_element('EntityDescriptor')
+  IDP_SSO_DESCRIPTOR_XPATH = xpath_for_metadata_element('IDPSSODescriptor')
+  SP_SSO_DESCRIPTOR_XPATH = xpath_for_metadata_element('SPSSODescriptor')
   ATTRIBUTE_AUTHORITY_DESCRIPTOR_XPATH =
-    '//*[local-name() = "AttributeAuthorityDescriptor" and ' \
-    'namespace-uri() = "urn:oasis:names:tc:SAML:2.0:metadata"]'
+    xpath_for_metadata_element('AttributeAuthorityDescriptor')
 
-  private_constant :ATTRIBUTE_AUTHORITY_DESCRIPTOR_XPATH
-
-  SP_SSO_DESCRIPTOR_XPATH =
-    '//*[local-name() = "SPSSODescriptor" and ' \
-    'namespace-uri() = "urn:oasis:names:tc:SAML:2.0:metadata"]'
-
-  private_constant :SP_SSO_DESCRIPTOR_XPATH
+  private_constant :ENTITY_DESCRIPTOR_XPATH, :IDP_SSO_DESCRIPTOR_XPATH,
+                   :ATTRIBUTE_AUTHORITY_DESCRIPTOR_XPATH,
+                   :SP_SSO_DESCRIPTOR_XPATH
 
   def set_saml_type(red, ed_node)
-    set_as_idp(red, ed_node)
-    set_as_aa(red, ed_node)
-    set_as_sp(red, ed_node)
+    tags = desired_entity_tags(ed_node)
+    untags = all_entity_tags - tags
+
+    red.update(idp: tags.include?(Tag::IDP),
+               sp: tags.include?(Tag::SP),
+               standalone_aa: tags.include?(Tag::STANDALONE_AA))
+
+    ke = red.known_entity
+    tags.each { |tag| ke.tag_as(tag) }
+    untags.each { |tag| ke.untag_as(tag) }
   end
 
-  def set_as_idp(red, ed_node)
-    return unless ed_node.xpath(IDP_SSO_DESCRIPTOR_XPATH).present?
+  def desired_entity_tags(ed_node)
+    tags = []
 
-    red.update(idp: true)
-    red.known_entity.tag_as(Tag::IDP)
-  end
-
-  def set_as_aa(red, ed_node)
-    return unless ed_node.xpath(ATTRIBUTE_AUTHORITY_DESCRIPTOR_XPATH).present?
-
-    if ed_node.xpath(IDP_SSO_DESCRIPTOR_XPATH).present?
-      red.update(standalone_aa: false)
-      red.known_entity.tag_as(Tag::AA)
-    else
-      red.update(standalone_aa: true)
-      red.known_entity.tag_as(Tag::STANDALONE_AA)
+    if entity_has_idp_role?(ed_node)
+      tags << Tag::IDP
+      tags << Tag::AA if entity_has_aa_role?(ed_node)
+    elsif entity_has_aa_role?(ed_node)
+      tags << Tag::STANDALONE_AA
     end
+
+    tags << Tag::SP if entity_has_sp_role?(ed_node)
+
+    tags
   end
 
-  def set_as_sp(red, ed_node)
-    return unless ed_node.xpath(SP_SSO_DESCRIPTOR_XPATH).present?
+  def all_entity_tags
+    [Tag::IDP, Tag::AA, Tag::STANDALONE_AA, Tag::SP]
+  end
 
-    red.update(sp: true)
-    red.known_entity.tag_as(Tag::SP)
+  def entity_has_idp_role?(ed_node)
+    ed_node.xpath(IDP_SSO_DESCRIPTOR_XPATH).present?
+  end
+
+  def entity_has_aa_role?(ed_node)
+    ed_node.xpath(ATTRIBUTE_AUTHORITY_DESCRIPTOR_XPATH).present?
+  end
+
+  def entity_has_sp_role?(ed_node)
+    ed_node.xpath(SP_SSO_DESCRIPTOR_XPATH).present?
   end
 end

--- a/spec/controllers/api/raw_entity_descriptors_controller_spec.rb
+++ b/spec/controllers/api/raw_entity_descriptors_controller_spec.rb
@@ -298,6 +298,44 @@ RSpec.describe API::RawEntityDescriptorsController, type: :controller do
               subject { record.standalone_aa }
               it { is_expected.to be_falsey }
             end
+
+            context 'for a service provider' do
+              let(:xml) { attributes_for(:raw_entity_descriptor_sp)[:xml] }
+
+              context 'idp' do
+                subject { record.idp }
+                it { is_expected.to be_falsey }
+              end
+
+              context 'sp' do
+                subject { record.sp }
+                it { is_expected.to be_truthy }
+              end
+
+              context 'standalone aa' do
+                subject { record.standalone_aa }
+                it { is_expected.to be_falsey }
+              end
+            end
+
+            context 'for a standalone aa' do
+              let(:xml) { attributes_for(:raw_entity_descriptor)[:xml] }
+
+              context 'idp' do
+                subject { record.idp }
+                it { is_expected.to be_falsey }
+              end
+
+              context 'sp' do
+                subject { record.sp }
+                it { is_expected.to be_falsey }
+              end
+
+              context 'standalone aa' do
+                subject { record.standalone_aa }
+                it { is_expected.to be_truthy }
+              end
+            end
           end
         end
 
@@ -332,10 +370,10 @@ RSpec.describe API::RawEntityDescriptorsController, type: :controller do
             context 'tags' do
               subject { record.tags.map(&:name) }
               let(:new_tags) { tags.append(source_tag) }
-              let(:all_tags) { new_tags + original_tags }
+              let(:all_tags) { new_tags + original_tags + ['idp'] }
 
               it 'appends the new tags' do
-                expect(subject).to contain_exactly(*all_tags)
+                expect(subject).to match_array(all_tags)
               end
             end
           end

--- a/spec/controllers/api/raw_entity_descriptors_controller_spec.rb
+++ b/spec/controllers/api/raw_entity_descriptors_controller_spec.rb
@@ -109,6 +109,44 @@ RSpec.describe API::RawEntityDescriptorsController, type: :controller do
               subject { record.standalone_aa }
               it { is_expected.to be_falsey }
             end
+
+            context 'for a service provider' do
+              let(:xml) { attributes_for(:raw_entity_descriptor_sp)[:xml] }
+
+              context 'idp' do
+                subject { record.idp }
+                it { is_expected.to be_falsey }
+              end
+
+              context 'sp' do
+                subject { record.sp }
+                it { is_expected.to be_truthy }
+              end
+
+              context 'standalone aa' do
+                subject { record.standalone_aa }
+                it { is_expected.to be_falsey }
+              end
+            end
+
+            context 'for a standalone aa' do
+              let(:xml) { attributes_for(:raw_entity_descriptor)[:xml] }
+
+              context 'idp' do
+                subject { record.idp }
+                it { is_expected.to be_falsey }
+              end
+
+              context 'sp' do
+                subject { record.sp }
+                it { is_expected.to be_falsey }
+              end
+
+              context 'standalone aa' do
+                subject { record.standalone_aa }
+                it { is_expected.to be_truthy }
+              end
+            end
           end
         end
 
@@ -134,8 +172,8 @@ RSpec.describe API::RawEntityDescriptorsController, type: :controller do
 
             context 'tags' do
               subject { record.tags.map(&:name) }
-              let(:all_tags) { tags.append(source_tag) }
-              it { is_expected.to eq(all_tags) }
+              let(:all_tags) { tags + [source_tag, 'idp'] }
+              it { is_expected.to match_array(all_tags) }
             end
           end
         end

--- a/spec/jobs/concerns/set_saml_type_from_xml_spec.rb
+++ b/spec/jobs/concerns/set_saml_type_from_xml_spec.rb
@@ -1,0 +1,134 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe SetSAMLTypeFromXML do
+  let(:known_entity) { spy(KnownEntity) }
+  let(:red) { spy(RawEntityDescriptor, known_entity: known_entity) }
+  let(:ed_node) { double(Nokogiri::XML::Node) }
+  let(:klass) { Class.new { include SetSAMLTypeFromXML } }
+  let(:absent_role_descriptor) { nil }
+  let(:present_role_descriptor) { double(present?: true) }
+  let(:idp_sso_descriptor) { absent_role_descriptor }
+  let(:attribute_authority_descriptor) { absent_role_descriptor }
+  let(:sp_sso_descriptor) { absent_role_descriptor }
+
+  let(:xpath_results) do
+    {
+      'IDPSSODescriptor' => idp_sso_descriptor,
+      'AttributeAuthorityDescriptor' => attribute_authority_descriptor,
+      'SPSSODescriptor' => sp_sso_descriptor
+    }
+  end
+
+  subject { klass.new }
+
+  before do
+    allow(ed_node).to receive(:xpath) do |path|
+      prefix = '//*[local-name() = "'
+      suffix = '" and namespace-uri() = "urn:oasis:names:tc:SAML:2.0:metadata"]'
+      pattern = "#{Regexp.escape(prefix)}(\\w+)#{Regexp.escape(suffix)}"
+      match = Regexp.new(pattern).match(path)
+
+      expect(match).to be_present
+      expect(xpath_results).to have_key(match[1])
+      xpath_results[match[1]]
+    end
+  end
+
+  describe '.set_saml_type' do
+    before { subject.set_saml_type(red, ed_node) }
+
+    # Sanity check; the XML would be invalid anyway
+    context 'with no type' do
+      it 'removes the flags' do
+        expect(red).to have_received(:update)
+          .with(idp: false, sp: false, standalone_aa: false)
+      end
+
+      it 'removes the tags' do
+        expect(known_entity).to have_received(:untag_as).with('idp')
+        expect(known_entity).to have_received(:untag_as).with('aa')
+        expect(known_entity).to have_received(:untag_as).with('sp')
+        expect(known_entity).to have_received(:untag_as).with('standalone-aa')
+      end
+    end
+
+    context 'with an IDPSSODescriptor' do
+      let(:idp_sso_descriptor) { present_role_descriptor }
+
+      it 'sets the flags' do
+        expect(red).to have_received(:update)
+          .with(idp: true, sp: false, standalone_aa: false)
+      end
+
+      it 'adds the tag' do
+        expect(known_entity).to have_received(:tag_as).with('idp')
+      end
+
+      it 'removes the other tags' do
+        expect(known_entity).to have_received(:untag_as).with('aa')
+        expect(known_entity).to have_received(:untag_as).with('sp')
+        expect(known_entity).to have_received(:untag_as).with('standalone-aa')
+      end
+    end
+
+    context 'with an SPSSODescriptor' do
+      let(:sp_sso_descriptor) { present_role_descriptor }
+
+      it 'sets the flags' do
+        expect(red).to have_received(:update)
+          .with(sp: true, idp: false, standalone_aa: false)
+      end
+
+      it 'adds the tag' do
+        expect(known_entity).to have_received(:tag_as).with('sp')
+      end
+
+      it 'removes the other tags' do
+        expect(known_entity).to have_received(:untag_as).with('idp')
+        expect(known_entity).to have_received(:untag_as).with('aa')
+        expect(known_entity).to have_received(:untag_as).with('standalone-aa')
+      end
+    end
+
+    context 'with an AttributeAuthorityDescriptor' do
+      let(:attribute_authority_descriptor) { present_role_descriptor }
+
+      it 'sets the flags' do
+        expect(red).to have_received(:update)
+          .with(sp: false, idp: false, standalone_aa: true)
+      end
+
+      it 'adds the tag' do
+        expect(known_entity).to have_received(:tag_as).with('standalone-aa')
+      end
+
+      it 'removes the other tags' do
+        expect(known_entity).to have_received(:untag_as).with('idp')
+        expect(known_entity).to have_received(:untag_as).with('aa')
+        expect(known_entity).to have_received(:untag_as).with('sp')
+      end
+    end
+
+    context 'with an IDPSSODescriptor + AttributeAuthorityDescriptor' do
+      let(:idp_sso_descriptor) { present_role_descriptor }
+      let(:attribute_authority_descriptor) { present_role_descriptor }
+
+      it 'sets the flags' do
+        expect(red).to have_received(:update)
+          .with(idp: true, sp: false, standalone_aa: false)
+      end
+
+      it 'adds the tags' do
+        expect(known_entity).to have_received(:tag_as).with('idp')
+        expect(known_entity).to have_received(:tag_as).with('aa')
+      end
+
+      it 'removes the other tags' do
+        expect(known_entity).to have_received(:untag_as).with('sp')
+        expect(known_entity).to have_received(:untag_as).with('standalone-aa')
+      end
+    end
+  end
+end


### PR DESCRIPTION
Adds support for multiple inbound types of entity via the RawEntityDescriptor API. Previously the API was purpose-built to support IdPs.

Actual diff for this PR:

https://github.com/ausaccessfed/saml-service/compare/ausaccessfed:41cc77c...ausaccessfed:195b7bf

Needs a merge of #127, #128 before merging this.