### PR TITLE
Relax URI scheme checks

### DIFF
--- a/app/models/localized_uri.rb
+++ b/app/models/localized_uri.rb
@@ -4,7 +4,7 @@ class LocalizedURI < Sequel::Model
 
   def validate
     super
-    uri_regexp = URI.regexp(%w(http https))
+    uri_regexp = URI.regexp(/(http|https)/i)
     validates_presence [:uri, :lang, :created_at, :updated_at]
     validates_format uri_regexp, :uri
   end

--- a/spec/models/localized_uri_spec.rb
+++ b/spec/models/localized_uri_spec.rb
@@ -27,6 +27,18 @@ describe LocalizedURI do
         expect(subject).to be_valid
       end
 
+      it 'supports hTtP' do
+        subject.lang = 'en'
+        subject.uri = 'hTtP://example.org'
+        expect(subject).to be_valid
+      end
+
+      it 'supports HttpS' do
+        subject.lang = 'en'
+        subject.uri = 'HttpS://example.org'
+        expect(subject).to be_valid
+      end
+
       it 'allows port number' do
         subject.lang = 'en'
         subject.uri = 'https://example.org:8080'


### PR DESCRIPTION
Upstream sent a URI with a captial letter in the scheme which is valid
to spec but we broke on.

This change ensures we accept a http/https schema with mixed/upper case
characters and continue processing.

Closes #134.