### PR TITLE
Split metadata instance identifier from primary tag

### DIFF
--- a/app/controllers/metadata_query_controller.rb
+++ b/app/controllers/metadata_query_controller.rb
@@ -90,8 +90,8 @@ class MetadataQueryController < ApplicationController
   end
 
   def ensure_metadata_instance
-    @metadata_instance =
-      MetadataInstance[primary_tag: params[:primary_tag]]
+    @metadata_instance = MetadataInstance[identifier: params[:instance]]
+
     if @metadata_instance
       @saml_renderer = Metadata::SAML.new(metadata_instance: @metadata_instance)
       return

--- a/app/models/metadata_instance.rb
+++ b/app/models/metadata_instance.rb
@@ -13,11 +13,11 @@ class MetadataInstance < Sequel::Model
     super
     validates_presence [:name, :created_at, :updated_at, :hash_algorithm,
                         :keypair, :federation_identifier, :validity_period,
-                        :primary_tag, :all_entities, :cache_period]
+                        :primary_tag, :identifier, :all_entities, :cache_period]
     validates_presence :ca_verify_depth if ca_key_infos.present?
     validates_presence :publication_info unless new?
 
-    validates_unique :primary_tag
+    validates_unique :identifier
 
     validates_includes %w(sha1 sha256), :hash_algorithm
   end

--- a/bin/configure.rb
+++ b/bin/configure.rb
@@ -89,6 +89,7 @@ class ConfigureCLI < Thor
   desc 'md_instance [options...]', 'Create or update a Metadata Instance'
   option :cert, desc: 'The file containing the metadata certificate'
   option :name, desc: 'The <EntitesDescriptor> name included in the XML'
+  option :identifier, desc: 'The identifier for the metadata instance'
   option :tag, desc: 'The primary tag for the metadata instance'
   option :hash, desc: 'The hash algorithm for signing (default: SHA256)',
                 default: 'SHA256'
@@ -107,7 +108,7 @@ class ConfigureCLI < Thor
     instance with the same tag will be updated with new configuration.
   LONGDESC
   def md_instance
-    instance = MetadataInstance.find_or_new(primary_tag: options[:tag])
+    instance = MetadataInstance.find_or_new(identifier: options[:identifier])
     instance.update(md_instance_attrs)
 
     update_publication_info(instance)
@@ -149,8 +150,9 @@ class ConfigureCLI < Thor
     keypair || raise('The provided certificate has not been registered')
 
     { name: opts[:name], federation_identifier: opts[:tag],
-      hash_algorithm: opts[:hash].downcase, validity_period: 7.days,
-      cache_period: 6.hours, keypair_id: keypair.id, all_entities: true }
+      primary_tag: opts[:tag], hash_algorithm: opts[:hash].downcase,
+      validity_period: 7.days, cache_period: 6.hours,
+      keypair_id: keypair.id, all_entities: true }
   end
 
   def update_publication_info(instance)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,22 +6,22 @@ Rails.application.routes.draw do
   URN_REGEXP = /(http|https|urn)(.*)?/
 
   scope '/mdq' do
-    match '/:primary_tag/entities',
+    match '/:instance/entities',
           to: 'metadata_query#all_entities', via: :all
 
-    match '/:primary_tag/entities/:identifier',
+    match '/:instance/entities/:identifier',
           to: 'metadata_query#specific_entity_sha1',
           constraints: # check regexp against decoded URI params
             -> (r) { r.path_parameters[:identifier].match(SHA1_REGEXP) },
           via: :all
 
-    match '/:primary_tag/entities/:identifier',
+    match '/:instance/entities/:identifier',
           to: 'metadata_query#tagged_entities',
           constraints:
             -> (r) { !r.path_parameters[:identifier].match(URN_REGEXP) },
           via: :all
 
-    match '/:primary_tag/entities/*identifier',
+    match '/:instance/entities/*identifier',
           to: 'metadata_query#specific_entity',
           constraints: { identifier: /.*/ }, via: :all
   end

--- a/db/migrate/20160920023804_rename_primary_tag_to_identifier_in_metadata_instance.rb
+++ b/db/migrate/20160920023804_rename_primary_tag_to_identifier_in_metadata_instance.rb
@@ -1,0 +1,17 @@
+Sequel.migration do
+  up do
+    alter_table :metadata_instances do
+      rename_column :primary_tag, :identifier
+      add_index :identifier, unique: true
+      drop_index :primary_tag
+    end
+  end
+
+  down do
+    alter_table :metadata_instances do
+      rename_column :identifier, :primary_tag
+      add_index :primary_tag, unique: true
+      drop_index :identifier
+    end
+  end
+end

--- a/db/migrate/20160920024949_add_primary_tag_to_metadata_instances.rb
+++ b/db/migrate/20160920024949_add_primary_tag_to_metadata_instances.rb
@@ -1,0 +1,10 @@
+Sequel.migration do
+  change do
+    # This field already existed but was renamed in the 20160920023804 migration
+    alter_table :metadata_instances do
+      add_column :primary_tag, String, null: false
+    end
+
+    execute 'update metadata_instances set primary_tag = identifier'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -196,6 +196,7 @@ Sequel.migration do
       column :federation_identifier, "varchar(255)", :null=>false
       column :validity_period, "int(11)", :null=>false
       column :cache_period, "int(11)", :default=>21600, :null=>false
+      column :primary_tag, "varchar(255)", :null=>false
       
       index [:keypair_id], :name=>:keypair_id
       index [:identifier], :unique=>true
@@ -860,5 +861,6 @@ self << "INSERT INTO `schema_migrations` (`filename`) VALUES ('20160316030021_ch
 self << "INSERT INTO `schema_migrations` (`filename`) VALUES ('20160530102028_api_subject_unique_x509.rb')"
 self << "INSERT INTO `schema_migrations` (`filename`) VALUES ('20160711003010_add_entity_source_id_to_entity_ids.rb')"
 self << "INSERT INTO `schema_migrations` (`filename`) VALUES ('20160920023804_rename_primary_tag_to_identifier_in_metadata_instance.rb')"
+self << "INSERT INTO `schema_migrations` (`filename`) VALUES ('20160920024949_add_primary_tag_to_metadata_instances.rb')"
                 end
               end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -191,14 +191,14 @@ Sequel.migration do
       column :ca_verify_depth, "int(11)"
       column :hash_algorithm, "varchar(255)", :null=>false
       foreign_key :keypair_id, :keypairs, :type=>"int(11)", :null=>false, :key=>[:id]
-      column :primary_tag, "varchar(255)", :null=>false
+      column :identifier, "varchar(255)", :null=>false
       column :all_entities, "tinyint(1)", :default=>true, :null=>false
       column :federation_identifier, "varchar(255)", :null=>false
       column :validity_period, "int(11)", :null=>false
       column :cache_period, "int(11)", :default=>21600, :null=>false
       
       index [:keypair_id], :name=>:keypair_id
-      index [:primary_tag], :unique=>true
+      index [:identifier], :unique=>true
     end
     
     create_table(:organization_display_names) do
@@ -859,5 +859,6 @@ self << "INSERT INTO `schema_migrations` (`filename`) VALUES ('20160314045620_se
 self << "INSERT INTO `schema_migrations` (`filename`) VALUES ('20160316030021_change_collation_to_binary.rb')"
 self << "INSERT INTO `schema_migrations` (`filename`) VALUES ('20160530102028_api_subject_unique_x509.rb')"
 self << "INSERT INTO `schema_migrations` (`filename`) VALUES ('20160711003010_add_entity_source_id_to_entity_ids.rb')"
+self << "INSERT INTO `schema_migrations` (`filename`) VALUES ('20160920023804_rename_primary_tag_to_identifier_in_metadata_instance.rb')"
                 end
               end

--- a/spec/bin/configure_spec.rb
+++ b/spec/bin/configure_spec.rb
@@ -136,6 +136,7 @@ RSpec.describe ConfigureCLI do
     let(:hash) { nil }
     let(:name) { "#{Faker::Lorem.word}.#{Faker::Internet.domain_name}" }
     let(:tag) { Faker::Lorem.word }
+    let(:identifier) { SecureRandom.urlsafe_base64 }
     let(:publisher) { Faker::Internet.url }
     let(:usage_policy) { Faker::Internet.url }
     let(:lang) { 'en' }
@@ -152,6 +153,7 @@ RSpec.describe ConfigureCLI do
       args = ['md_instance',
               '--cert', cert_file,
               '--name', name,
+              '--identifier', identifier,
               '--tag', tag,
               '--publisher', publisher,
               '--usage-policy', usage_policy,
@@ -163,7 +165,7 @@ RSpec.describe ConfigureCLI do
     end
 
     context 'when the metadata instance exists' do
-      let!(:instance) { create(:metadata_instance, primary_tag: tag) }
+      let!(:instance) { create(:metadata_instance, identifier: identifier) }
 
       it 'does not create a new metadata instance' do
         expect { run }.not_to change(MetadataInstance, :count)

--- a/spec/controllers/metadata_query_controller_spec.rb
+++ b/spec/controllers/metadata_query_controller_spec.rb
@@ -26,8 +26,10 @@ RSpec.describe MetadataQueryController, type: :controller do
       it { is_expected.to have_http_status(:not_acceptable) }
     end
 
-    context 'with invalid primary_tag (MetadataInstance)' do
-      let(:fake_primary_tag) { Faker::Lorem.word }
+    context 'with invalid instance identifier' do
+      let(:instance_identifier) { Faker::Lorem.word }
+      let!(:metadata_instance) { nil }
+
       before do
         request.accept = saml_content
         query
@@ -110,7 +112,12 @@ RSpec.describe MetadataQueryController, type: :controller do
   end
 
   let(:saml_content) { MetadataQueryController::SAML_CONTENT_TYPE }
+  let(:instance_identifier) { metadata_instance.identifier }
   let(:primary_tag) { Faker::Lorem.word }
+
+  let!(:metadata_instance) do
+    create :metadata_instance, primary_tag: primary_tag
+  end
 
   describe '#all_entities' do
     context 'GET' do
@@ -123,7 +130,7 @@ RSpec.describe MetadataQueryController, type: :controller do
 
           before do
             request.accept = saml_content
-            get :all_entities, primary_tag: primary_tag
+            get :all_entities, instance: instance_identifier
           end
 
           context 'response' do
@@ -160,7 +167,7 @@ RSpec.describe MetadataQueryController, type: :controller do
 
           context 'initial request' do
             def run
-              get :all_entities, primary_tag: primary_tag
+              get :all_entities, instance: instance_identifier
             end
 
             context 'uncached server side' do
@@ -202,7 +209,7 @@ RSpec.describe MetadataQueryController, type: :controller do
 
           context 'subsequent requests' do
             def run
-              get :all_entities, primary_tag: primary_tag
+              get :all_entities, instance: instance_identifier
             end
 
             before do
@@ -273,13 +280,13 @@ RSpec.describe MetadataQueryController, type: :controller do
 
       context 'invalid client request' do
         it_behaves_like 'invalid requests' do
-          let(:query) { get :all_entities, primary_tag: primary_tag }
+          let(:query) { get :all_entities, instance: instance_identifier }
         end
       end
     end
 
     include_examples 'non get request' do
-      let(:query) { post :all_entities, primary_tag: primary_tag }
+      let(:query) { post :all_entities, instance: instance_identifier }
     end
   end
 
@@ -288,9 +295,6 @@ RSpec.describe MetadataQueryController, type: :controller do
       context 'GET' do
         before { request.accept = saml_content }
         context 'valid client request' do
-          let!(:metadata_instance) do
-            create :metadata_instance, primary_tag: primary_tag
-          end
           let(:etag) do
             controller
               .send(:generate_descriptor_etag, entity_descriptor.known_entity)
@@ -413,7 +417,7 @@ RSpec.describe MetadataQueryController, type: :controller do
 
           context 'invalid entity_descriptor' do
             before do
-              get :specific_entity, primary_tag: primary_tag,
+              get :specific_entity, instance: instance_identifier,
                                     identifier: 'https://example.edu/shibboleth'
             end
 
@@ -433,7 +437,7 @@ RSpec.describe MetadataQueryController, type: :controller do
         context 'invalid client request' do
           it_behaves_like 'invalid requests' do
             let(:query) do
-              get :specific_entity, primary_tag: primary_tag,
+              get :specific_entity, instance: instance_identifier,
                                     identifier: entity_id
             end
           end
@@ -442,14 +446,15 @@ RSpec.describe MetadataQueryController, type: :controller do
 
       include_examples 'non get request' do
         let(:query) do
-          post :specific_entity, primary_tag: primary_tag, identifier: entity_id
+          post :specific_entity, instance: instance_identifier,
+                                 identifier: entity_id
         end
       end
     end
 
     context 'With URI identifier' do
       def run
-        get :specific_entity, primary_tag: primary_tag,
+        get :specific_entity, instance: instance_identifier,
                               identifier: entity_id
       end
 
@@ -472,7 +477,7 @@ RSpec.describe MetadataQueryController, type: :controller do
     context 'With sha1 identifier' do
       def run
         identifier = "{sha1}#{Digest::SHA1.hexdigest(entity_id)}"
-        get :specific_entity_sha1, primary_tag: primary_tag,
+        get :specific_entity_sha1, instance: instance_identifier,
                                    identifier: identifier
       end
 
@@ -500,13 +505,9 @@ RSpec.describe MetadataQueryController, type: :controller do
     context 'GET' do
       context 'valid client request' do
         context 'MetadataInstance has no entities matching tag' do
-          let!(:metadata_instance) do
-            create :metadata_instance, primary_tag: primary_tag
-          end
-
           before do
             request.accept = saml_content
-            get :tagged_entities, primary_tag: primary_tag,
+            get :tagged_entities, instance: instance_identifier,
                                   identifier: secondary_tag
           end
 
@@ -523,9 +524,6 @@ RSpec.describe MetadataQueryController, type: :controller do
         end
 
         context 'MetadataInstance has entities matching tag' do
-          let!(:metadata_instance) do
-            create :metadata_instance, primary_tag: primary_tag
-          end
           let!(:known_entities) do
             create_list(:known_entity, 2, :with_idp) +
               create_list(:known_entity, 2, :with_raw_entity_descriptor)
@@ -560,7 +558,7 @@ RSpec.describe MetadataQueryController, type: :controller do
           end
 
           def run
-            get :tagged_entities, primary_tag: primary_tag,
+            get :tagged_entities, instance: instance_identifier,
                                   identifier: secondary_tag
           end
 
@@ -694,7 +692,7 @@ RSpec.describe MetadataQueryController, type: :controller do
       context 'invalid client request' do
         it_behaves_like 'invalid requests' do
           let(:query) do
-            get :tagged_entities, primary_tag: primary_tag,
+            get :tagged_entities, instance: instance_identifier,
                                   identifier: secondary_tag
           end
         end
@@ -703,7 +701,7 @@ RSpec.describe MetadataQueryController, type: :controller do
 
     include_examples 'non get request' do
       let(:query) do
-        post :tagged_entities, primary_tag: primary_tag,
+        post :tagged_entities, instance: instance_identifier,
                                identifier: secondary_tag
       end
     end

--- a/spec/factories/metadata_instances.rb
+++ b/spec/factories/metadata_instances.rb
@@ -11,6 +11,7 @@ FactoryGirl.define do
     federation_identifier { Faker::Lorem.word }
 
     primary_tag { SecureRandom.urlsafe_base64(16) }
+    identifier { SecureRandom.urlsafe_base64(16) }
     all_entities true
 
     after :create do |mi|

--- a/spec/models/metadata_instance_spec.rb
+++ b/spec/models/metadata_instance_spec.rb
@@ -16,7 +16,8 @@ describe MetadataInstance do
   it { is_expected.to validate_presence :cache_period }
 
   it { is_expected.to validate_presence :primary_tag }
-  it { is_expected.to validate_unique :primary_tag }
+  it { is_expected.to validate_presence :identifier }
+  it { is_expected.to validate_unique :identifier }
   it { is_expected.to validate_presence :all_entities }
 
   context 'optional attributes' do

--- a/spec/routes/metadata_query_controller_spec.rb
+++ b/spec/routes/metadata_query_controller_spec.rb
@@ -2,47 +2,47 @@
 require 'rails_helper'
 
 RSpec.describe 'Routes for MetadataQueryController', type: :routing do
-  let(:primary_tag) { Faker::Lorem.word }
+  let(:instance) { Faker::Lorem.word }
   let(:identifier) { Faker::Internet.url }
   let(:sha1_identifier) { Digest::SHA1.hexdigest identifier }
   let(:basic_identifier) { Faker::Lorem.word }
 
-  it 'routes /:primary_tag/entities to #all_entities' do
-    expect(get("/mdq/#{primary_tag}/entities"))
+  it 'routes /:instance/entities to #all_entities' do
+    expect(get("/mdq/#{instance}/entities"))
       .to route_to(
         controller: 'metadata_query',
         action: 'all_entities',
-        primary_tag: primary_tag
+        instance: instance
       )
   end
 
-  it 'routes /:primary_tag/entities/:identifier to #specific_entity' do
-    expect(get("/mdq/#{primary_tag}/entities/#{identifier}"))
+  it 'routes /:instance/entities/:identifier to #specific_entity' do
+    expect(get("/mdq/#{instance}/entities/#{identifier}"))
       .to route_to(
         controller: 'metadata_query',
         action: 'specific_entity',
-        primary_tag: primary_tag,
+        instance: instance,
         identifier: identifier
       )
   end
 
-  it 'routes /:primary_tag/entities/:identifier to #specific_entity_sha1' do
-    uri = URI.encode("/mdq/#{primary_tag}/entities/{sha1}#{sha1_identifier}")
+  it 'routes /:instance/entities/:identifier to #specific_entity_sha1' do
+    uri = URI.encode("/mdq/#{instance}/entities/{sha1}#{sha1_identifier}")
     expect(get(uri))
       .to route_to(
         controller: 'metadata_query',
         action: 'specific_entity_sha1',
-        primary_tag: primary_tag,
+        instance: instance,
         identifier: "{sha1}#{sha1_identifier}"
       )
   end
 
-  it 'routes /:primary_tag/entities/:basic_identifier to #tagged_entities' do
-    expect(get("/mdq/#{primary_tag}/entities/#{basic_identifier}"))
+  it 'routes /:instance/entities/:basic_identifier to #tagged_entities' do
+    expect(get("/mdq/#{instance}/entities/#{basic_identifier}"))
       .to route_to(
         controller: 'metadata_query',
         action: 'tagged_entities',
-        primary_tag: primary_tag,
+        instance: instance,
         identifier: basic_identifier
       )
   end


### PR DESCRIPTION
Up front: This is a proposed change, but not really a no-brainer. It's a bit of a shift in how saml-service works currently, so it's open to discussion on whether this is the best approach.

Backstory for this change:

* Currently we have multiple metadata feeds each with their own "purpose". Each feed necessarily has entities tagged in a certain way because it's how we determine their grouping
* We also currently have a unique constraint on `metadata_instances.primary_tag`, because we're maintaining the metadata instances automatically with `bin/configure.rb` and we need a way to identify them
* As a rationale for how this unique constraint came about, our `metadata_instances.primary_tag` is necessarily unique in the current model, because the base URL for MDQ needs to resolve to exactly one `MetadataInstance`

This approach becomes less elegant when we need to present an existing `primary_tag` in another way, because we need to:

* add a new tag in parallel to the existing tag
* apply the tag to all existing data
* modify the sync code to ensure the tag is applied to future data

The current use case for this is that we're adding another feed which is signed with a different keypair, so it needs a different `MetadataInstance`, but it MUST have exactly the same set of entities as our federation metadata.

There are 3 options I considered:

1. Add a new tag for this new feed, keep the code changes to a bare minimum
2. Remove the unique constraint on `primary_tag` and try to find another way to resolve the ambiguity it creates (I didn't get very far down this line of thinking)
3. Use a `MetadataInstance#identifier` as the URL component for MDQ, and separate it from the `primary_tag` field

To me, number 3 seemed like the cleaner option because it moves us away from the situation where we can only have one metadata URL per primary tag.