### PR TITLE
Filter out incomplete SP attributes during ETL

### DIFF
--- a/app/jobs/concerns/etl/service_providers.rb
+++ b/app/jobs/concerns/etl/service_providers.rb
@@ -86,7 +86,7 @@ module ETL
 
     def acs_attributes(acs, ac_data)
       ac_data[:attributes].each do |attr_data|
-        next if not_correctly_specified(attr_data)
+        next unless correctly_specified?(attr_data)
 
         base = fr_attributes[attr_data[:id]]
         ra = requested_attribute(acs, attr_data, base)
@@ -95,14 +95,13 @@ module ETL
       end
     end
 
-    def not_correctly_specified(attr_data)
+    def correctly_specified?(attr_data)
       # Don't represent attributes that require specification but
       # have not yet had specific values associated.
       # For example eduPersonEntitlement but no entitlement values
       # requested by the SP using our tooling as yet.
-      attr_data[:specificationRequired].present? &&
-        attr_data[:specificationRequired] &&
-        !attr_data[:values].present?
+      attr_data[:specificationRequired].blank? ||
+        (attr_data[:specificationRequired] && attr_data[:values].present?)
     end
 
     def requested_attribute(acs, attr_data, base)

--- a/app/jobs/concerns/etl/service_providers.rb
+++ b/app/jobs/concerns/etl/service_providers.rb
@@ -86,6 +86,15 @@ module ETL
 
     def acs_attributes(acs, ac_data)
       ac_data[:attributes].each do |attr_data|
+        # Don't represent attributes that require specification but
+        # have not yet had specific values associated.
+        # For example eduPersonEntitlement but no entitlement values
+        # requested by the SP using our tooling as yet.
+        if attr_data[:specificationRequired].present? &&
+           attr_data[:specificationRequired] &&
+           !attr_data[:values].present?
+          next
+        end
         base = fr_attributes[attr_data[:id]]
         ra = requested_attribute(acs, attr_data, base)
         acs.add_requested_attribute(ra)

--- a/app/jobs/concerns/etl/service_providers.rb
+++ b/app/jobs/concerns/etl/service_providers.rb
@@ -86,20 +86,23 @@ module ETL
 
     def acs_attributes(acs, ac_data)
       ac_data[:attributes].each do |attr_data|
-        # Don't represent attributes that require specification but
-        # have not yet had specific values associated.
-        # For example eduPersonEntitlement but no entitlement values
-        # requested by the SP using our tooling as yet.
-        if attr_data[:specificationRequired].present? &&
-           attr_data[:specificationRequired] &&
-           !attr_data[:values].present?
-          next
-        end
+        next if not_correctly_specified(attr_data)
+
         base = fr_attributes[attr_data[:id]]
         ra = requested_attribute(acs, attr_data, base)
         acs.add_requested_attribute(ra)
         NameFormat.create(uri: base[:name_format][:uri], attribute: ra)
       end
+    end
+
+    def not_correctly_specified(attr_data)
+      # Don't represent attributes that require specification but
+      # have not yet had specific values associated.
+      # For example eduPersonEntitlement but no entitlement values
+      # requested by the SP using our tooling as yet.
+      attr_data[:specificationRequired].present? &&
+        attr_data[:specificationRequired] &&
+        !attr_data[:values].present?
     end
 
     def requested_attribute(acs, attr_data, base)

--- a/spec/support/jobs/concerns/etl/service_providers.rb
+++ b/spec/support/jobs/concerns/etl/service_providers.rb
@@ -64,6 +64,7 @@ RSpec.shared_examples 'ETL::ServiceProviders' do
       name: Faker::Lorem.word,
       is_required: false,
       reason: Faker::Lorem.word,
+      specificationRequired: ra[:specificationRequired] ||= false,
       values: []
     }
   end
@@ -131,7 +132,15 @@ RSpec.shared_examples 'ETL::ServiceProviders' do
         description: Faker::Lorem.sentence,
         oid: "#{Faker::Number.number(4)}:#{Faker::Number.number(4)}"
       }
-    end
+    end.push(
+      {
+        id: attribute_count,
+        description: Faker::Lorem.sentence,
+        oid: "#{Faker::Number.number(4)}:#{Faker::Number.number(4)}",
+        values: [],
+        specificationRequired: true
+      }
+    )
   end
 
   let(:attributes_list) do
@@ -171,6 +180,10 @@ RSpec.shared_examples 'ETL::ServiceProviders' do
 
     context 'created instance' do
       before { run }
+
+      it 'is provided with attributes that are not acceptable' do
+        expect(attribute_instances.size).to eq(attribute_count + 1)
+      end
 
       it 'requests expected number of attributes' do
         run

--- a/spec/support/jobs/concerns/etl/service_providers.rb
+++ b/spec/support/jobs/concerns/etl/service_providers.rb
@@ -133,13 +133,11 @@ RSpec.shared_examples 'ETL::ServiceProviders' do
         oid: "#{Faker::Number.number(4)}:#{Faker::Number.number(4)}"
       }
     end.push(
-      {
-        id: attribute_count,
-        description: Faker::Lorem.sentence,
-        oid: "#{Faker::Number.number(4)}:#{Faker::Number.number(4)}",
-        values: [],
-        specificationRequired: true
-      }
+      id: attribute_count,
+      description: Faker::Lorem.sentence,
+      oid: "#{Faker::Number.number(4)}:#{Faker::Number.number(4)}",
+      values: [],
+      specificationRequired: true
     )
   end
 


### PR DESCRIPTION
Currently the FR API gives us all the things and we ingest that
faithfully.

In the case of specified attributes for SP however we only want to
render XML where approved attributes also exist.

This change ensures ETL correctly follows that desire.