### PR TITLE
Revert "Filter out incomplete SP attributes during ETL"

### DIFF
--- a/app/jobs/concerns/etl/service_providers.rb
+++ b/app/jobs/concerns/etl/service_providers.rb
@@ -86,22 +86,11 @@ module ETL
 
     def acs_attributes(acs, ac_data)
       ac_data[:attributes].each do |attr_data|
-        next unless correctly_specified?(attr_data)
-
         base = fr_attributes[attr_data[:id]]
         ra = requested_attribute(acs, attr_data, base)
         acs.add_requested_attribute(ra)
         NameFormat.create(uri: base[:name_format][:uri], attribute: ra)
       end
-    end
-
-    def correctly_specified?(attr_data)
-      # Don't represent attributes that require specification but
-      # have not yet had specific values associated.
-      # For example eduPersonEntitlement but no entitlement values
-      # requested by the SP using our tooling as yet.
-      attr_data[:specificationRequired].blank? ||
-        (attr_data[:specificationRequired] && attr_data[:values].present?)
     end
 
     def requested_attribute(acs, attr_data, base)

--- a/spec/support/jobs/concerns/etl/service_providers.rb
+++ b/spec/support/jobs/concerns/etl/service_providers.rb
@@ -64,7 +64,6 @@ RSpec.shared_examples 'ETL::ServiceProviders' do
       name: Faker::Lorem.word,
       is_required: false,
       reason: Faker::Lorem.word,
-      specificationRequired: ra[:specificationRequired] ||= false,
       values: []
     }
   end
@@ -132,13 +131,7 @@ RSpec.shared_examples 'ETL::ServiceProviders' do
         description: Faker::Lorem.sentence,
         oid: "#{Faker::Number.number(4)}:#{Faker::Number.number(4)}"
       }
-    end.push(
-      id: attribute_count,
-      description: Faker::Lorem.sentence,
-      oid: "#{Faker::Number.number(4)}:#{Faker::Number.number(4)}",
-      values: [],
-      specificationRequired: true
-    )
+    end
   end
 
   let(:attributes_list) do
@@ -178,10 +171,6 @@ RSpec.shared_examples 'ETL::ServiceProviders' do
 
     context 'created instance' do
       before { run }
-
-      it 'is provided with attributes that are not acceptable' do
-        expect(attribute_instances.size).to eq(attribute_count + 1)
-      end
 
       it 'requests expected number of attributes' do
         run


### PR DESCRIPTION
Reverts ausaccessfed/saml-service#144

Errors on deployment to test federation that need review in normal business hours.