### PR TITLE
Correct fault when JSON key not presented

### DIFF
--- a/app/jobs/concerns/etl/service_providers.rb
+++ b/app/jobs/concerns/etl/service_providers.rb
@@ -100,7 +100,7 @@ module ETL
       # have not yet had specific values associated.
       # For example eduPersonEntitlement but no entitlement values
       # requested by the SP using our tooling as yet.
-      attr_data[:specificationRequired].blank? ||
+      attr_data.fetch(:specificationRequired, nil).blank? ||
         (attr_data[:specificationRequired] && attr_data[:values].present?)
     end
 


### PR DESCRIPTION
Under production workloads FR treats `specificationRequired` as being
false if not provided and thus does not offer it in most JSON exports.

The code developed in the previous PR works in the opposite direction
expecting that the JSON schema will always be fully populated.

This commit introduces a default value when `specificationRequired` is
not presented to address the `ImplicitSchema::ValidationError`
which was being reported.