### PR TITLE
Remove attributes on [IDP|SP]SSORoleDescriptor

### DIFF
--- a/lib/metadata/saml.rb
+++ b/lib/metadata/saml.rb
@@ -421,9 +421,7 @@ module Metadata
     end
 
     def idp_sso_descriptor(idp)
-      attributes = {}
-      attributes[:WantAuthnRequestsSigned] = idp.want_authn_requests_signed
-      root.IDPSSODescriptor(ns, attributes) do |idp_node|
+      root.IDPSSODescriptor(ns) do |idp_node|
         sso_descriptor(idp, idp_node)
 
         idp.single_sign_on_services.each do |ssos|
@@ -467,10 +465,7 @@ module Metadata
     end
 
     def sp_sso_descriptor(sp)
-      attributes = {}
-      attributes[:AuthnRequestsSigned] = sp.authn_requests_signed
-      attributes[:WantAssertionsSigned] = sp.want_assertions_signed
-      root.SPSSODescriptor(ns, attributes) do |sp_node|
+      root.SPSSODescriptor(ns) do |sp_node|
         sso_descriptor(sp, sp_node)
 
         sp.assertion_consumer_services.each do |acs|

--- a/spec/support/metadata/idp_sso_descriptor.rb
+++ b/spec/support/metadata/idp_sso_descriptor.rb
@@ -27,17 +27,8 @@ RSpec.shared_examples 'IDPSSODescriptor xml' do
 
   context 'attributes' do
     context 'WantAuthnRequestsSigned' do
-      it 'is rendered' do
-        expect(node['WantAuthnRequestsSigned']).to be_truthy
-      end
-      context 'when explicitly set' do
-        let(:idp_sso_descriptor) do
-          create :idp_sso_descriptor, :with_requests_signed
-        end
-        it 'is rendered' do
-          expect(node['WantAuthnRequestsSigned'])
-            .to eq(idp_sso_descriptor.want_authn_requests_signed.to_s)
-        end
+      it 'is not rendered' do
+        expect(node['WantAuthnRequestsSigned']).to be_falsey
       end
     end
   end

--- a/spec/support/metadata/sp_sso_descriptor.rb
+++ b/spec/support/metadata/sp_sso_descriptor.rb
@@ -20,32 +20,14 @@ RSpec.shared_examples 'SPSSODescriptor xml' do
     let(:node) { xml.first(:xpath, sp_sso_descriptor_path) }
 
     context 'AuthnRequestsSigned' do
-      it 'is rendered' do
-        expect(node['AuthnRequestsSigned']).to be_truthy
-      end
-      context 'when explicitly set' do
-        let(:sp_sso_descriptor) do
-          create :sp_sso_descriptor, :with_authn_requests_signed
-        end
-        it 'is rendered' do
-          expect(node['AuthnRequestsSigned'])
-            .to eq(sp_sso_descriptor.authn_requests_signed.to_s)
-        end
+      it 'is not rendered' do
+        expect(node['AuthnRequestsSigned']).to be_falsey
       end
     end
 
     context 'WantAssertionsSigned' do
-      it 'is rendered' do
-        expect(node['WantAssertionsSigned']).to be_truthy
-      end
-      context 'when explicitly set' do
-        let(:sp_sso_descriptor) do
-          create :sp_sso_descriptor, :with_want_assertions_signed
-        end
-        it 'is rendered' do
-          expect(node['WantAssertionsSigned'])
-            .to eq(sp_sso_descriptor.want_assertions_signed.to_s)
-        end
+      it 'is not rendered' do
+        expect(node['WantAssertionsSigned']).to be_falsey
       end
     end
   end


### PR DESCRIPTION
This commit returns SAML Service to rendering SSODescriptors the same
as FR. Thus the attributes `WantAssertionsSigned`, `AuthnRequestsSigned`
for SPSSODescriptor, `WantAuthnRequestsSigned` for IDPSSODescriptor are
no longer present in the final XML.

Closes #148.