### PR TITLE
Order xml elements

### DIFF
--- a/lib/metadata/saml.rb
+++ b/lib/metadata/saml.rb
@@ -348,7 +348,8 @@ module Metadata
 
         # SPSSODescriptor specific
         if rd.is_a? SPSSODescriptor
-          rd.discovery_response_services.each do |rds|
+          rdss = rd.discovery_response_services{|ds| ds.order(:index, :id)}
+          rdss.each do |rds|
             idpdisc.DiscoveryResponse do |rds_node|
               indexed_endpoint(rds, rds_node)
             end
@@ -371,15 +372,15 @@ module Metadata
     def sso_descriptor(sso, scope)
       role_descriptor(sso, scope)
 
-      sso.artifact_resolution_services.each do |ars|
+      sso.artifact_resolution_services{|ds| ds.order(:index, :id)}.each do |ars|
         artifact_resolution_service(ars)
       end
 
-      sso.single_logout_services.each do |slo|
+      sso.single_logout_services{|ds| ds.order(:id)}.each do |slo|
         single_logout_service(slo)
       end
 
-      sso.manage_name_id_services.each do |slo|
+      sso.manage_name_id_services{|ds| ds.order(:id)}.each do |slo|
         manage_name_id_service(slo)
       end
 
@@ -424,15 +425,15 @@ module Metadata
       root.IDPSSODescriptor(ns) do |idp_node|
         sso_descriptor(idp, idp_node)
 
-        idp.single_sign_on_services.each do |ssos|
+        idp.single_sign_on_services{|ds| ds.order(:id)}.each do |ssos|
           single_sign_on_service(ssos)
         end
 
-        idp.name_id_mapping_services.each do |nidms|
+        idp.name_id_mapping_services{|ds| ds.order(:id)}.each do |nidms|
           name_id_mapping_service(nidms)
         end
 
-        idp.assertion_id_request_services.each do |aidrs|
+        idp.assertion_id_request_services{|ds| ds.order(:id)}.each do |aidrs|
           assertion_id_request_service(aidrs)
         end
 
@@ -468,7 +469,7 @@ module Metadata
       root.SPSSODescriptor(ns) do |sp_node|
         sso_descriptor(sp, sp_node)
 
-        sp.assertion_consumer_services.each do |acs|
+        sp.assertion_consumer_services{|ds| ds.order(:index, :id)}.each do |acs|
           assertion_consumer_service(acs)
         end
 
@@ -516,11 +517,11 @@ module Metadata
       root.AttributeAuthorityDescriptor(ns) do |aad_node|
         role_descriptor(aad, aad_node)
 
-        aad.attribute_services.each do |as|
+        aad.attribute_services{|ds| ds.order(:id)}.each do |as|
           attribute_service(as)
         end
 
-        aad.assertion_id_request_services.each do |aidrs|
+        aad.assertion_id_request_services{|ds| ds.order(:id)}.each do |aidrs|
           assertion_id_request_service(aidrs)
         end
 

--- a/lib/metadata/saml.rb
+++ b/lib/metadata/saml.rb
@@ -19,7 +19,7 @@ module Metadata
         scope.parent[:FriendlyName] = attr.friendly_name
       end
 
-      attr.attribute_values.each do |attr_val|
+      attr.attribute_values { |ds| ds.order(:id) }.each do |attr_val|
         attribute_value(attr_val)
       end
     end
@@ -172,7 +172,7 @@ module Metadata
 
     def key_authority(ed)
       shibmd.KeyAuthority(VerifyDepth: ed.ca_verify_depth) do |_|
-        ed.ca_key_infos.each do |ca|
+        ed.ca_key_infos { |ds| ds.order(:id) }.each do |ca|
           key_info(ca)
         end
       end
@@ -197,7 +197,7 @@ module Metadata
                 publicationId: instance_id }
 
       mdrpi.PublicationInfo(ns, attrs) do |_|
-        publication_info.usage_policies.each do |up|
+        publication_info.usage_policies { |ds| ds.order(:id) }.each do |up|
           mdrpi.UsagePolicy(up.uri, 'xml:lang' => up.lang)
         end
       end
@@ -205,7 +205,7 @@ module Metadata
 
     def entity_attribute(ea)
       mdattr.EntityAttributes(ns) do |_|
-        ea.attributes.each do |attr|
+        ea.attributes { |ds| ds.order(:id) }.each do |attr|
           attribute(attr)
         end
       end
@@ -244,21 +244,21 @@ module Metadata
         signature_element if root_node
         entity_descriptor_extensions(ed, root_node)
 
-        ed.idp_sso_descriptors.each do |idp|
+        ed.idp_sso_descriptors { |ds| ds.order(:id) }.each do |idp|
           idp_sso_descriptor(idp) if idp.functioning?
         end
 
-        ed.sp_sso_descriptors.each do |sp|
+        ed.sp_sso_descriptors { |ds| ds.order(:id) }.each do |sp|
           sp_sso_descriptor(sp) if sp.functioning?
         end
 
-        ed.attribute_authority_descriptors.each do |aad|
+        ed.attribute_authority_descriptors { |ds| ds.order(:id) }.each do |aad|
           attribute_authority_descriptor(aad) if aad.functioning?
         end
 
         organization(ed.organization)
 
-        ed.contact_people.each do |cp|
+        ed.contact_people { |ds| ds.order(:id) }.each do |cp|
           contact_person(cp)
         end
       end
@@ -279,7 +279,8 @@ module Metadata
                                .registration_instant_utc.xmlschema
       }
       mdrpi.RegistrationInfo(ns, attributes) do |_|
-        mi.registration_info.registration_policies.each do |rp|
+        rps = mi.registration_info.registration_policies { |ds| ds.order(:id) }
+        rps.each do |rp|
           mdrpi.RegistrationPolicy(rp.uri, 'xml:lang' => rp.lang)
         end
       end
@@ -287,15 +288,15 @@ module Metadata
 
     def organization(org)
       root.Organization(ns) do |_|
-        org.organization_names.each do |name|
+        org.organization_names { |ds| ds.order(:id) }.each do |name|
           root.OrganizationName(name.value, 'xml:lang' => name.lang)
         end
 
-        org.organization_display_names.each do |dname|
+        org.organization_display_names { |ds| ds.order(:id) }.each do |dname|
           root.OrganizationDisplayName(dname.value, 'xml:lang' => dname.lang)
         end
 
-        org.organization_urls.each do |url|
+        org.organization_urls { |ds| ds.order(:id) }.each do |url|
           root.OrganizationURL(url.uri, 'xml:lang' => url.lang)
         end
       end
@@ -322,11 +323,11 @@ module Metadata
 
       role_descriptor_extensions(rd, scope)
 
-      rd.key_descriptors.each do |kd|
+      rd.key_descriptors { |ds| ds.order(:id) }.each do |kd|
         key_descriptor(kd) unless kd.disabled
       end
 
-      rd.contact_people.each { |cp| contact_person(cp) }
+      rd.contact_people { |ds| ds.order(:id) }.each { |cp| contact_person(cp) }
     end
 
     def role_descriptor_extensions(rd, scope)
@@ -336,7 +337,7 @@ module Metadata
         ui_info(rd.ui_info) if rd.ui_info.present?
 
         if rd.scopes?
-          rd.scopes.each do |s|
+          rd.scopes { |ds| ds.order(:id) }.each do |s|
             shibmd_scope(s)
           end
         end
@@ -348,7 +349,7 @@ module Metadata
 
         # SPSSODescriptor specific
         if rd.is_a? SPSSODescriptor
-          rdss = rd.discovery_response_services{|ds| ds.order(:index, :id)}
+          rdss = rd.discovery_response_services { |ds| ds.order(:index, :id) }
           rdss.each do |rds|
             idpdisc.DiscoveryResponse do |rds_node|
               indexed_endpoint(rds, rds_node)
@@ -372,19 +373,20 @@ module Metadata
     def sso_descriptor(sso, scope)
       role_descriptor(sso, scope)
 
-      sso.artifact_resolution_services{|ds| ds.order(:index, :id)}.each do |ars|
+      acss = sso.artifact_resolution_services { |ds| ds.order(:index, :id) }
+      acss.each do |ars|
         artifact_resolution_service(ars)
       end
 
-      sso.single_logout_services{|ds| ds.order(:id)}.each do |slo|
+      sso.single_logout_services { |ds| ds.order(:id) }.each do |slo|
         single_logout_service(slo)
       end
 
-      sso.manage_name_id_services{|ds| ds.order(:id)}.each do |slo|
+      sso.manage_name_id_services { |ds| ds.order(:id) }.each do |slo|
         manage_name_id_service(slo)
       end
 
-      sso.name_id_formats.each do |ndif|
+      sso.name_id_formats { |ds| ds.order(:id) }.each do |ndif|
         root.NameIDFormat(ndif.uri)
       end
     end
@@ -425,23 +427,23 @@ module Metadata
       root.IDPSSODescriptor(ns) do |idp_node|
         sso_descriptor(idp, idp_node)
 
-        idp.single_sign_on_services{|ds| ds.order(:id)}.each do |ssos|
+        idp.single_sign_on_services { |ds| ds.order(:id) }.each do |ssos|
           single_sign_on_service(ssos)
         end
 
-        idp.name_id_mapping_services{|ds| ds.order(:id)}.each do |nidms|
+        idp.name_id_mapping_services { |ds| ds.order(:id) }.each do |nidms|
           name_id_mapping_service(nidms)
         end
 
-        idp.assertion_id_request_services{|ds| ds.order(:id)}.each do |aidrs|
+        idp.assertion_id_request_services { |ds| ds.order(:id) }.each do |aidrs|
           assertion_id_request_service(aidrs)
         end
 
-        idp.attribute_profiles.each do |ap|
+        idp.attribute_profiles { |ds| ds.order(:id) }.each do |ap|
           root.AttributeProfile(ap.uri)
         end
 
-        idp.attributes.each do |a|
+        idp.attributes { |ds| ds.order(:id) }.each do |a|
           attribute(a)
         end
       end
@@ -469,11 +471,12 @@ module Metadata
       root.SPSSODescriptor(ns) do |sp_node|
         sso_descriptor(sp, sp_node)
 
-        sp.assertion_consumer_services{|ds| ds.order(:index, :id)}.each do |acs|
+        acss = sp.assertion_consumer_services { |ds| ds.order(:index, :id) }
+        acss.each do |acs|
           assertion_consumer_service(acs)
         end
 
-        sp.attribute_consuming_services.each do |attrcs|
+        sp.attribute_consuming_services { |ds| ds.order(:id) }.each do |attrcs|
           attribute_consuming_service(attrcs)
         end
       end
@@ -491,16 +494,16 @@ module Metadata
         isDefault: acs.default
       }
       root.AttributeConsumingService(ns, attributes) do |_acs_node|
-        acs.service_names.each do |service_name|
+        acs.service_names { |ds| ds.order(:id) }.each do |service_name|
           root.ServiceName(service_name.value, 'xml:lang' => service_name.lang)
         end
 
-        acs.service_descriptions.each do |service_description|
-          root.ServiceDescription(service_description.value,
-                                  'xml:lang' => service_description.lang)
+        acs.service_descriptions { |ds| ds.order(:id) }.each do |service_desc|
+          root.ServiceDescription(service_desc.value,
+                                  'xml:lang' => service_desc.lang)
         end
 
-        acs.requested_attributes.each do |ra|
+        acs.requested_attributes { |ds| ds.order(:id) }.each do |ra|
           requested_attribute(ra)
         end
       end
@@ -517,23 +520,23 @@ module Metadata
       root.AttributeAuthorityDescriptor(ns) do |aad_node|
         role_descriptor(aad, aad_node)
 
-        aad.attribute_services{|ds| ds.order(:id)}.each do |as|
+        aad.attribute_services { |ds| ds.order(:id) }.each do |as|
           attribute_service(as)
         end
 
-        aad.assertion_id_request_services{|ds| ds.order(:id)}.each do |aidrs|
+        aad.assertion_id_request_services { |ds| ds.order(:id) }.each do |aidrs|
           assertion_id_request_service(aidrs)
         end
 
-        aad.name_id_formats.each do |nidf|
+        aad.name_id_formats { |ds| ds.order(:id) }.each do |nidf|
           root.NameIDFormat(nidf.uri)
         end
 
-        aad.attribute_profiles.each do |ap|
+        aad.attribute_profiles { |ds| ds.order(:id) }.each do |ap|
           root.AttributeProfile(ap.uri)
         end
 
-        aad.attributes.each do |attr|
+        aad.attributes { |ds| ds.order(:id) }.each do |attr|
           attribute(attr)
         end
       end
@@ -551,29 +554,29 @@ module Metadata
 
     def ui_info(info)
       mdui.UIInfo(ns) do |_|
-        info.display_names.each do |display_name|
+        info.display_names { |ds| ds.order(:id) }.each do |display_name|
           mdui.DisplayName(display_name.value, 'xml:lang' => display_name.lang)
         end
 
-        info.descriptions.each do |description|
+        info.descriptions { |ds| ds.order(:id) }.each do |description|
           mdui.Description(description.value, 'xml:lang' => description.lang)
         end
 
-        info.keyword_lists.each do |keywords|
+        info.keyword_lists { |ds| ds.order(:id) }.each do |keywords|
           mdui.Keywords(keywords.content, 'xml:lang' => keywords.lang)
         end
 
-        info.logos.each do |logo|
+        info.logos { |ds| ds.order(:id) }.each do |logo|
           attributes = { height: logo.height, width: logo.width }
           attributes['xml:lang'] = logo.lang if logo.lang.present?
           mdui.Logo(logo.uri, attributes)
         end
 
-        info.information_urls.each do |url|
+        info.information_urls { |ds| ds.order(:id) }.each do |url|
           mdui.InformationURL(url.uri, 'xml:lang' => url.lang)
         end
 
-        info.privacy_statement_urls.each do |url|
+        info.privacy_statement_urls { |ds| ds.order(:id) }.each do |url|
           mdui.PrivacyStatementURL(url.uri, 'xml:lang' => url.lang)
         end
       end
@@ -581,16 +584,16 @@ module Metadata
 
     def disco_hints(disco)
       mdui.DiscoHints(ns) do |_|
-        disco.ip_hints.each do |ip_hint|
+        disco.ip_hints { |ds| ds.order(:id) }.each do |ip_hint|
           mdui.IPHint(ip_hint.block)
         end
 
-        disco.domain_hints.each do |domain_hint|
+        disco.domain_hints { |ds| ds.order(:id) }.each do |domain_hint|
           mdui.DomainHint(domain_hint.domain)
         end
 
-        disco.geolocation_hints.each do |geolocation_hint|
-          mdui.GeolocationHint(geolocation_hint.uri)
+        disco.geolocation_hints { |ds| ds.order(:id) }.each do |gh|
+          mdui.GeolocationHint(gh.uri)
         end
       end
     end


### PR DESCRIPTION
Ensures that all elements are consistently ordered within AAF metadata, per previous approach in FR.

For `IndexedEndpoint` specifically we order first by index and then by ID to satisfy both misbehaving SAML implementations and SAML spec nuances.