### PR TITLE
Specification attributes from FR not filtered when values are empty

### DIFF
--- a/app/jobs/concerns/etl/service_providers.rb
+++ b/app/jobs/concerns/etl/service_providers.rb
@@ -100,7 +100,7 @@ module ETL
       # have not yet had specific values associated.
       # For example eduPersonEntitlement but no entitlement values
       # requested by the SP using our tooling as yet.
-      attr_data.fetch(:specificationRequired, nil).blank? ||
+      attr_data.fetch(:specificationRequired, false) == false ||
         (attr_data[:specificationRequired] && attr_data[:values].present?)
     end
 

--- a/app/jobs/concerns/etl/service_providers.rb
+++ b/app/jobs/concerns/etl/service_providers.rb
@@ -100,8 +100,8 @@ module ETL
       # have not yet had specific values associated.
       # For example eduPersonEntitlement but no entitlement values
       # requested by the SP using our tooling as yet.
-      attr_data.fetch(:specificationRequired, false) == false ||
-        (attr_data[:specificationRequired] && attr_data[:values].present?)
+      attr_data.fetch(:specification, false) == false ||
+        (attr_data[:specification] && attr_data[:values].present?)
     end
 
     def requested_attribute(acs, attr_data, base)

--- a/spec/support/jobs/concerns/etl/service_providers.rb
+++ b/spec/support/jobs/concerns/etl/service_providers.rb
@@ -64,8 +64,8 @@ RSpec.shared_examples 'ETL::ServiceProviders' do
       name: Faker::Lorem.word,
       is_required: false,
       reason: Faker::Lorem.word,
-      specificationRequired: ra[:specificationRequired] ||= false,
-      values: []
+      specification: ra[:specification] ||= false,
+      values: ra[:values]
     }
   end
 
@@ -130,14 +130,22 @@ RSpec.shared_examples 'ETL::ServiceProviders' do
       {
         id: i,
         description: Faker::Lorem.sentence,
-        oid: "#{Faker::Number.number(4)}:#{Faker::Number.number(4)}"
+        oid: "#{Faker::Number.number(4)}:#{Faker::Number.number(4)}",
+        values: []
       }
     end.push(
       id: attribute_count,
       description: Faker::Lorem.sentence,
       oid: "#{Faker::Number.number(4)}:#{Faker::Number.number(4)}",
       values: [],
-      specificationRequired: true
+      specification: true
+    ).push(
+      id: attribute_count + 1,
+      description: Faker::Lorem.sentence,
+      oid: "#{Faker::Number.number(4)}:#{Faker::Number.number(4)}",
+      values: [{ approved: true, value: Faker::Number.number(4) },
+               { approved: false, value: Faker::Number.number(3) }],
+      specification: true
     )
   end
 
@@ -180,13 +188,13 @@ RSpec.shared_examples 'ETL::ServiceProviders' do
       before { run }
 
       it 'is provided with attributes that are not acceptable' do
-        expect(attribute_instances.size).to eq(attribute_count + 1)
+        expect(attribute_instances.size).to eq(attribute_count + 2)
       end
 
       it 'requests expected number of attributes' do
         run
         expect(AttributeConsumingService.last.reload.requested_attributes.size)
-          .to eq(attribute_count)
+          .to eq(attribute_count + 1)
       end
 
       context 'assertion_consumer_services' do


### PR DESCRIPTION
When importing from FR we invalidly looked at the key
`specificationRequired` when determining if the attribute in question
should only be accepted if it also provided specific attribute values
which had been approved by administrators.

The correct key is `specification` which this update changes to.
Relevant FR API export code: 
https://github.com/ausaccessfed/federationregistry/blob/develop/app/plugins/base/grails-app/domain/aaf/fr/foundation/SPSSODescriptor.groovy#L113