### PR TITLE
Support research-scholarship, sirtfi and blacklist tags

### DIFF
--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -19,4 +19,7 @@ class Tag < Sequel::Model
   AA = 'aa'.freeze
   STANDALONE_AA = 'standalone-aa'.freeze
   SP = 'sp'.freeze
+  RESEARCH_SCHOLARSHIP = 'research-scholarship'.freeze
+  SIRTFI = 'sirtfi'.freeze
+  BLACKLIST = 'blacklist'.freeze
 end

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -19,7 +19,7 @@ class Tag < Sequel::Model
   AA = 'aa'.freeze
   STANDALONE_AA = 'standalone-aa'.freeze
   SP = 'sp'.freeze
-  RESEARCH_SCHOLARSHIP = 'research-scholarship'.freeze
+  RESEARCH_SCHOLARSHIP = 'research-and-scholarship'.freeze
   SIRTFI = 'sirtfi'.freeze
   BLACKLIST = 'blacklist'.freeze
 end

--- a/spec/jobs/concerns/set_saml_type_from_xml_spec.rb
+++ b/spec/jobs/concerns/set_saml_type_from_xml_spec.rb
@@ -100,7 +100,7 @@ RSpec.describe SetSAMLTypeFromXML do
         expect(known_entity).to have_received(:untag_as).with('standalone-aa')
         expect(known_entity).to have_received(:untag_as).with('sirtfi')
         expect(known_entity).to have_received(:untag_as)
-          .with('research-scholarship')
+          .with('research-and-scholarship')
       end
     end
 
@@ -135,7 +135,7 @@ RSpec.describe SetSAMLTypeFromXML do
 
         it 'adds the tag' do
           expect(known_entity).to have_received(:tag_as)
-            .with('research-scholarship')
+            .with('research-and-scholarship')
         end
       end
     end
@@ -171,7 +171,7 @@ RSpec.describe SetSAMLTypeFromXML do
 
         it 'adds the tag' do
           expect(known_entity).to have_received(:tag_as)
-            .with('research-scholarship')
+            .with('research-and-scholarship')
         end
       end
     end

--- a/spec/models/known_entity_spec.rb
+++ b/spec/models/known_entity_spec.rb
@@ -102,4 +102,71 @@ RSpec.describe KnownEntity do
       end
     end
   end
+
+  describe '::with_any_tag' do
+    let!(:blacklisted_entity) { create(:known_entity) }
+    let!(:allowed_entity) { create(:known_entity) }
+
+    let!(:tags) do
+      [
+        create(:tag, name: 'aaf', known_entity: allowed_entity),
+        create(:tag, name: 'aaf', known_entity: blacklisted_entity),
+        create(:tag, name: 'blacklist', known_entity: blacklisted_entity)
+      ]
+    end
+
+    it 'filters the blacklisted entity' do
+      expect(KnownEntity.with_any_tag('aaf')).not_to include(blacklisted_entity)
+    end
+
+    it 'includes the allowed entity' do
+      expect(KnownEntity.with_any_tag('aaf')).to include(allowed_entity)
+    end
+
+    context 'with `include_blacklisted: true`' do
+      it 'includes the blacklisted entity' do
+        expect(KnownEntity.with_any_tag('aaf', include_blacklisted: true))
+          .to include(blacklisted_entity)
+      end
+
+      it 'includes the allowed entity' do
+        expect(KnownEntity.with_any_tag('aaf', include_blacklisted: true))
+          .to include(allowed_entity)
+      end
+    end
+  end
+
+  describe '::with_all_tags' do
+    let!(:blacklisted_entity) { create(:known_entity) }
+    let!(:allowed_entity) { create(:known_entity) }
+
+    let!(:tags) do
+      [
+        create(:tag, name: 'aaf', known_entity: allowed_entity),
+        create(:tag, name: 'aaf', known_entity: blacklisted_entity),
+        create(:tag, name: 'blacklist', known_entity: blacklisted_entity)
+      ]
+    end
+
+    it 'filters the blacklisted entity' do
+      expect(KnownEntity.with_all_tags('aaf'))
+        .not_to include(blacklisted_entity)
+    end
+
+    it 'includes the allowed entity' do
+      expect(KnownEntity.with_all_tags('aaf')).to include(allowed_entity)
+    end
+
+    context 'with `include_blacklisted: true`' do
+      it 'includes the blacklisted entity' do
+        expect(KnownEntity.with_all_tags('aaf', include_blacklisted: true))
+          .to include(blacklisted_entity)
+      end
+
+      it 'includes the allowed entity' do
+        expect(KnownEntity.with_all_tags('aaf', include_blacklisted: true))
+          .to include(allowed_entity)
+      end
+    end
+  end
 end


### PR DESCRIPTION
* `research-and-scholarship` is automatically tagged where an entity attribute indicates:
    * IdP support for R&S
    * SP conformance to R&S
* `sirtfi` is automatically tagged for entities that assert compliance
* Entities tagged with `blacklist` are filtered from published metadata feeds

R&S: https://refeds.org/category/research-and-scholarship
SIRTFI: https://refeds.org/sirtfi