### PR TITLE
Correctly handle boolean parameters via API

### DIFF
--- a/app/controllers/api/raw_entity_descriptors_controller.rb
+++ b/app/controllers/api/raw_entity_descriptors_controller.rb
@@ -80,7 +80,7 @@ module API
     end
 
     def valid_patch_params?
-      patch_params[:tags] && %w[true false].include?(patch_params[:enabled])
+      patch_params[:tags] && [true, false].include?(patch_params[:enabled])
     end
 
     def access_path

--- a/spec/controllers/api/raw_entity_descriptors_controller_spec.rb
+++ b/spec/controllers/api/raw_entity_descriptors_controller_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe API::RawEntityDescriptorsController, type: :controller do
         request.env['HTTP_X509_DN'] = "CN=#{api_subject.x509_cn}".dup
       end
 
-      patch :update, params: {
+      patch :update, as: :json, params: {
         tag: source_tag,
         base64_urlsafe_entity_id: base64_urlsafe_entity_id,
         raw_entity_descriptor: raw_entity_descriptor


### PR DESCRIPTION
Real clients send the request body as JSON, but in a Rails controller test the payload is delivered (or simulated as being delivered) as a form encoded request body. This has the effect that all values are converted to strings, instead of being serialized / deserialized correctly like a JSON payload would be.

Passing the `as: :json` argument to the test request method (`patch` in this case) restores the correct behaviour and delivers real boolean values to the application.

This bug was introduced in #157.