### PR TITLE
Stop metadata from changing after each FR sync

### DIFF
--- a/lib/metadata/saml.rb
+++ b/lib/metadata/saml.rb
@@ -259,7 +259,11 @@ module Metadata
 
         organization(ed.organization)
 
-        ed.contact_people { |ds| ds.order(:contact_id) }.each do |cp|
+        contact_people = ed.contact_people do |ds|
+          ds.order(:contact_type_id, :contact_id)
+        end
+
+        contact_people.each do |cp|
           contact_person(cp)
         end
       end

--- a/lib/metadata/saml.rb
+++ b/lib/metadata/saml.rb
@@ -259,7 +259,7 @@ module Metadata
 
         organization(ed.organization)
 
-        ed.contact_people { |ds| ds.order(:id) }.each do |cp|
+        ed.contact_people { |ds| ds.order(:contact_id) }.each do |cp|
           contact_person(cp)
         end
       end

--- a/lib/metadata/saml.rb
+++ b/lib/metadata/saml.rb
@@ -206,7 +206,7 @@ module Metadata
 
     def entity_attribute(ea)
       mdattr.EntityAttributes(ns) do |_|
-        ea.attributes { |ds| ds.order(:id) }.each do |attr|
+        ea.attributes { |ds| ds.order(:name) }.each do |attr|
           attribute(attr)
         end
       end
@@ -444,7 +444,7 @@ module Metadata
           root.AttributeProfile(ap.uri)
         end
 
-        idp.attributes { |ds| ds.order(:id) }.each do |a|
+        idp.attributes { |ds| ds.order(:name) }.each do |a|
           attribute(a)
         end
       end
@@ -537,7 +537,7 @@ module Metadata
           root.AttributeProfile(ap.uri)
         end
 
-        aad.attributes { |ds| ds.order(:id) }.each do |attr|
+        aad.attributes { |ds| ds.order(:name) }.each do |attr|
           attribute(attr)
         end
       end

--- a/lib/metadata/saml.rb
+++ b/lib/metadata/saml.rb
@@ -529,7 +529,7 @@ module Metadata
           assertion_id_request_service(aidrs)
         end
 
-        aad.name_id_formats { |ds| ds.order(:id) }.each do |nidf|
+        aad.name_id_formats { |ds| ds.order(:uri) }.each do |nidf|
           root.NameIDFormat(nidf.uri)
         end
 

--- a/spec/controllers/api/raw_entity_descriptors_controller_spec.rb
+++ b/spec/controllers/api/raw_entity_descriptors_controller_spec.rb
@@ -3,11 +3,17 @@
 require 'rails_helper'
 
 RSpec.describe API::RawEntityDescriptorsController, type: :controller do
+  def unique_words(count)
+    words = []
+    words << Faker::Lorem.word until words.uniq.length == count
+    words.uniq
+  end
+
   describe 'patch :update' do
     let(:entity_source) { create(:entity_source) }
     let(:source_tag) { entity_source.source_tag }
 
-    let(:tags) { [Faker::Lorem.word, Faker::Lorem.word] }
+    let(:tags) { unique_words(2) }
     let(:host_name) { Faker::Internet.domain_name }
     let(:entity_id_uri) { "https://#{host_name}/shibboleth" }
     let(:base64_urlsafe_entity_id) { Base64.urlsafe_encode64(entity_id_uri) }
@@ -225,7 +231,7 @@ RSpec.describe API::RawEntityDescriptorsController, type: :controller do
       end
 
       context 'when the raw entity descriptor exists' do
-        let(:original_tags) { [Faker::Lorem.word, Faker::Lorem.word] }
+        let(:original_tags) { unique_words(2) }
         let(:original_host_name) { Faker::Internet.domain_name }
         let(:original_enabled) { [true, false].sample }
         let(:original_xml) do


### PR DESCRIPTION
Three things in metadata were still not being rendered in the same order each time, after the changes in #152:

* `Contact` information. Even though `Contact` records are preserved, `ContactPerson` is blown away each time, and those records determine the order of contacts in XML. This is resolved by sorting by `contact_type_id` / `contact_id`;
* `NameIDFormat`. We can sort by the URI to resolve this easily;
* `Attribute` information. Since well-formed metadata shouldn't have multiple `Attribute` elements with the same `name` as siblings, we can sort by `name` to resolve this.

I've also included a fix for an intermittent test case failure which continues to cause problems in CI.