### PR TITLE
Use higher rank entity if not functioning

### DIFF
--- a/lib/metadata/saml.rb
+++ b/lib/metadata/saml.rb
@@ -61,10 +61,21 @@ module Metadata
           signature_element
           entities_descriptor_extensions
 
-          filter_known_entities(known_entities).each do |ke_list|
-            known_entity(ke_list)
-          end
+          render_known_entities(known_entity_list(known_entities))
         end
+      end
+    end
+
+    def render_known_entities(known_entity_list)
+      known_entity_list.each do |e|
+        entity_descriptor(e) if e.instance_of? EntityDescriptor
+        raw_entity_descriptor(e) if e.instance_of? RawEntityDescriptor
+      end
+    end
+
+    def known_entity_list(known_entities)
+      filter_known_entities(known_entities).map do |ke_list|
+        known_entity(ke_list)
       end
     end
 
@@ -95,12 +106,12 @@ module Metadata
       entities.sort_by { |ke| ke.entity_source.try(:rank) }
     end
 
-    def known_entity(ke_list)
-      ke_list.each do |ke|
+    def known_entity(known_entity_by_rank)
+      known_entity_by_rank.each do |ke|
         ed = ke.entity_descriptor
         rad = ke.raw_entity_descriptor
-        return entity_descriptor(ed) if ed.try(:functioning?)
-        return raw_entity_descriptor(rad) if rad.try(:functioning?)
+        return ed if ed.try(:functioning?)
+        return rad if rad.try(:functioning?)
       end
     end
 

--- a/lib/metadata/saml.rb
+++ b/lib/metadata/saml.rb
@@ -61,8 +61,8 @@ module Metadata
           signature_element
           entities_descriptor_extensions
 
-          filter_known_entities(known_entities).each do |ke|
-            known_entity(ke)
+          filter_known_entities(known_entities).each do |ke_list|
+            known_entity(ke_list)
           end
         end
       end
@@ -82,8 +82,8 @@ module Metadata
     # Lowest rank for EntitySource where multiple instances of
     # EntityDescriptor represented by the same EntityId exist is authoritative.
     def filter_known_entities(known_entities)
-      group_by_eid(known_entities).flat_map do |_, entities|
-        sort_eid_hash_by_source_rank(entities).first
+      group_by_eid(known_entities).map do |_, entities|
+        sort_eid_hash_by_source_rank(entities)
       end
     end
 
@@ -95,11 +95,12 @@ module Metadata
       entities.sort_by { |ke| ke.entity_source.try(:rank) }
     end
 
-    def known_entity(ke)
-      if ke.entity_descriptor.try(:functioning?)
-        entity_descriptor(ke.entity_descriptor)
-      elsif ke.raw_entity_descriptor.try(:functioning?)
-        raw_entity_descriptor(ke.raw_entity_descriptor)
+    def known_entity(ke_list)
+      ke_list.each do |ke|
+        ed = ke.entity_descriptor
+        rad = ke.raw_entity_descriptor
+        return entity_descriptor(ed) if ed.try(:functioning?)
+        return raw_entity_descriptor(rad) if rad.try(:functioning?)
       end
     end
 


### PR DESCRIPTION
Right now if there are multiple entity sources for the same entity (i.e. hosted-idp source with EntityID X, federation registry source with EntityID X), the entity that ends up in the metadata feed will be lowest ranked one. 

But what happens if this entity is disabled (via flag in saml-service)? Does it fallback to the other entity that is of a higher rank? ...No.

This PR fixes that.

