### PR TITLE
 Fix derived tags behaviour

### DIFF
--- a/app/models/derived_tag.rb
+++ b/app/models/derived_tag.rb
@@ -7,7 +7,8 @@ class DerivedTag < Sequel::Model
 
   def validate
     super
-    validates_presence %i[tag_name when_tags unless_tags created_at updated_at]
+    validates_presence %i[tag_name created_at updated_at]
+    validates_not_null %i[when_tags unless_tags]
     validates_format VALID_TAG, :tag_name
     validates_format VALID_TAG_LIST, %i[when_tags unless_tags]
   end

--- a/spec/factories/derived_tags.rb
+++ b/spec/factories/derived_tags.rb
@@ -4,6 +4,15 @@ FactoryGirl.define do
   factory :derived_tag do
     tag_name { Faker::Lorem.word }
     when_tags { Faker::Lorem.words.join(',') }
-    unless_tags { Faker::Lorem.words.join(',') }
+    unless_tags do
+      when_tag_names = when_tags.split(',')
+
+      (1..100).lazy
+              .map { Faker::Lorem.word }
+              .reject { |w| when_tag_names.include?(w) }
+              .take(5)
+              .to_a
+              .join(',')
+    end
   end
 end

--- a/spec/models/derived_tag_spec.rb
+++ b/spec/models/derived_tag_spec.rb
@@ -9,8 +9,22 @@ RSpec.describe DerivedTag do
     subject { build(:derived_tag) }
 
     it { is_expected.to validate_presence(:tag_name) }
-    it { is_expected.to validate_presence(:when_tags) }
-    it { is_expected.to validate_presence(:unless_tags) }
+
+    it 'requires when_tags but allows blank' do
+      subject.when_tags = ''
+      expect(subject).to be_valid
+
+      subject.when_tags = nil
+      expect(subject).not_to be_valid
+    end
+
+    it 'requires unless_tags but allows blank' do
+      subject.unless_tags = ''
+      expect(subject).to be_valid
+
+      subject.unless_tags = nil
+      expect(subject).not_to be_valid
+    end
 
     it 'permits only a valid tag_name' do
       valid = SecureRandom.urlsafe_base64


### PR DESCRIPTION
Fixes a few issues:

* Multiple derived tags with the same `tag_name` were not behaving well
* Removing a `DerivedTag` would ensure that the `Tag` records remained forever
* Unable to create `DerivedTag` with blank conditions (especially `unless_tags`, which we don't always need)