### PR TITLE
Revert to non-threaded configuration

### DIFF
--- a/config/puma.rb
+++ b/config/puma.rb
@@ -9,8 +9,8 @@ preload_app!
 daemonize
 
 bind puma_config['bind']
-workers 2
-threads 8, 32
+workers 3
+threads 1, 1
 tag 'saml'
 pidfile 'tmp/pids/puma.pid'
 


### PR DESCRIPTION
We don't quite have the thread safety story right yet. It's causing a few runtime exceptions.