### PR TITLE
Allow entity precedence in discovery api

### DIFF
--- a/app/controllers/api/discovery_entities_controller.rb
+++ b/app/controllers/api/discovery_entities_controller.rb
@@ -55,20 +55,16 @@ module API
     def filter_by_rank(entities)
       entities.collect(&:known_entity)
               .group_by(&:entity_id)
-              .map { |_, es| known_entity(order_known_entities_by_rank(es)) }
+              .map { |_, es| functioning_entity(order_by_rank(es)) }
     end
 
-    def order_known_entities_by_rank(entities)
-      entities.sort_by { |ke| ke.entity_source.try(:rank) }
+    def order_by_rank(known_entities)
+      known_entities.sort_by { |ke| ke.entity_source.try(:rank) }
     end
 
-    def known_entity(known_entities_by_rank)
-      known_entities_by_rank.each do |ke|
-        ed = ke.entity_descriptor
-        rad = ke.raw_entity_descriptor
-        return ed if ed.try(:functioning?)
-        return rad if rad.try(:functioning?)
-      end
+    def functioning_entity(known_entities_by_rank)
+      known_entities_by_rank.find(&:functioning_entity)
+                            .try(:functioning_entity)
     end
 
     def ed_containing_sp

--- a/app/controllers/api/discovery_entities_controller.rb
+++ b/app/controllers/api/discovery_entities_controller.rb
@@ -54,7 +54,6 @@ module API
 
     def filter_by_rank(entities)
       entities.collect(&:known_entity)
-              .uniq
               .group_by(&:entity_id)
               .map { |_, es| known_entity(order_known_entities_by_rank(es)) }
     end

--- a/app/controllers/api/discovery_entities_controller.rb
+++ b/app/controllers/api/discovery_entities_controller.rb
@@ -10,8 +10,7 @@ module API
         @identity_provider_entities =
           filter_by_rank(ed_containing_idp + red_containing_idp)
         @service_provider_entities =
-          ed_containing_sp.select(&:functioning?) +
-          red_containing_sp.select(&:functioning?)
+          filter_by_rank(ed_containing_sp + red_containing_sp)
       end
     end
 

--- a/app/models/known_entity.rb
+++ b/app/models/known_entity.rb
@@ -81,6 +81,13 @@ class KnownEntity < Sequel::Model
     desired_derived_tags.each { |tag| apply_derived_tag(tag) }
   end
 
+  def functioning_entity
+    return entity_descriptor if entity_descriptor.try(:functioning?)
+    return raw_entity_descriptor if raw_entity_descriptor.try(:functioning?)
+
+    nil
+  end
+
   private
 
   def apply_derived_tag(name)

--- a/lib/metadata/saml.rb
+++ b/lib/metadata/saml.rb
@@ -75,7 +75,8 @@ module Metadata
 
     def known_entity_list(known_entities)
       filter_known_entities(known_entities).map do |ke_list|
-        known_entity(ke_list)
+        ke_list.find(&:functioning_entity)
+               .try(:functioning_entity)
       end
     end
 
@@ -104,15 +105,6 @@ module Metadata
 
     def sort_eid_hash_by_source_rank(entities)
       entities.sort_by { |ke| ke.entity_source.try(:rank) }
-    end
-
-    def known_entity(known_entity_by_rank)
-      known_entity_by_rank.each do |ke|
-        ed = ke.entity_descriptor
-        rad = ke.raw_entity_descriptor
-        return ed if ed.try(:functioning?)
-        return rad if rad.try(:functioning?)
-      end
     end
 
     def root_entity_descriptor(ke)

--- a/spec/controllers/api/discovery_entities_controller_spec.rb
+++ b/spec/controllers/api/discovery_entities_controller_spec.rb
@@ -4,33 +4,54 @@ require 'rails_helper'
 
 RSpec.describe API::DiscoveryEntitiesController, type: :controller do
   let(:api_subject) { create(:api_subject, :authorized, permission: '*') }
-  let!(:identity_provider) { create(:entity_descriptor) }
-  let!(:service_provider) { create(:entity_descriptor) }
+
+  let!(:entity_source) { create(:entity_source, rank: rand(1..10)) }
+
+  let(:idp_known_entity) do
+    create(:known_entity, entity_source: entity_source)
+  end
+
+  let(:raw_ed_idp_known_entity) do
+    create(:known_entity, entity_source: entity_source)
+  end
+
+  let!(:identity_provider) do
+    create(:entity_descriptor, known_entity: idp_known_entity)
+  end
 
   let!(:idp_sso_descriptor) do
     create(:idp_sso_descriptor, entity_descriptor: identity_provider)
   end
 
   let!(:raw_ed_idp) do
-    create(:raw_entity_descriptor_idp)
+    create(:raw_entity_descriptor_idp, known_entity: raw_ed_idp_known_entity)
   end
 
+  let(:sp_known_entity) { create(:known_entity, entity_source: entity_source) }
+
+  let!(:service_provider) do
+    create(:entity_descriptor, known_entity: sp_known_entity)
+  end
   let!(:raw_ed_sp) do
-    create(:raw_entity_descriptor_sp)
+    create(:raw_entity_descriptor_sp, known_entity: sp_known_entity)
   end
 
   let!(:sp_sso_descriptor) do
     create(:sp_sso_descriptor, entity_descriptor: service_provider)
   end
 
+  let!(:other_identity_provider) {}
+  let!(:other_idp_sso_descriptor) {}
+  let!(:other_raw_ed_idp) {}
+
   before do
     request.env['HTTP_X509_DN'] = "CN=#{api_subject.x509_cn}".dup if api_subject
   end
 
-  subject { response }
-
   describe 'get :index' do
     before { get :index, format: :json }
+
+    subject { response }
 
     it { is_expected.to have_http_status(:ok) }
     it { is_expected.to render_template('api/discovery_entities/index') }
@@ -88,6 +109,196 @@ RSpec.describe API::DiscoveryEntitiesController, type: :controller do
       it 'excludes the service provider' do
         expect(assigns[:service_provider_entities])
           .not_to include(raw_ed_sp)
+      end
+    end
+
+    context 'with other entity source' do
+      let!(:other_entity_source) { create(:entity_source, rank: other_rank) }
+
+      let!(:other_idp_known_entity) do
+        create(:known_entity, entity_source: other_entity_source,
+                              enabled: other_idp_enabled)
+      end
+
+      context 'other ed-idp same entity id as existing ed-idp' do
+        let!(:other_identity_provider) do
+          other = create(:entity_descriptor,
+                         known_entity: other_idp_known_entity,
+                         enabled: other_idp_enabled)
+          other.entity_id.update(uri: identity_provider.entity_id.uri)
+          other
+        end
+
+        let!(:other_idp_sso_descriptor) do
+          create(:idp_sso_descriptor,
+                 entity_descriptor: other_identity_provider)
+        end
+
+        context 'other has lower rank' do
+          let!(:other_rank) { entity_source.rank - 1 }
+
+          context 'but not functional' do
+            let!(:other_idp_enabled) { false }
+
+            it 'includes the original, ignores other' do
+              expect(assigns[:identity_provider_entities])
+                .to include(identity_provider)
+                .and not_include(other_identity_provider)
+            end
+          end
+
+          context 'and is functional' do
+            let!(:other_idp_enabled) { true }
+
+            it 'includes the other, ignores original' do
+              expect(assigns[:identity_provider_entities])
+                .to include(other_identity_provider)
+                .and not_include(identity_provider)
+            end
+          end
+        end
+
+        context 'other has higher rank' do
+          let!(:other_rank) { entity_source.rank + 1 }
+
+          context 'but not functional' do
+            let!(:other_idp_enabled) { false }
+
+            it 'includes the original, ignores other' do
+              expect(assigns[:identity_provider_entities])
+                .to include(identity_provider)
+                .and not_include(other_identity_provider)
+            end
+          end
+
+          context 'and is functional' do
+            let!(:other_idp_enabled) { true }
+
+            it 'includes the original, ignores other' do
+              expect(assigns[:identity_provider_entities])
+                .to include(identity_provider)
+                .and not_include(other_identity_provider)
+            end
+          end
+        end
+      end
+
+      context 'other rad-idp with same entity id as rad-idp' do
+        let!(:other_raw_ed_idp) do
+          other = create(:raw_entity_descriptor_idp,
+                         known_entity: other_idp_known_entity,
+                         enabled: other_idp_enabled,
+                         idp: true)
+          other.entity_id.update(uri: raw_ed_idp.entity_id.uri)
+          other
+        end
+
+        context 'other has lower rank' do
+          let!(:other_rank) { entity_source.rank - 1 }
+
+          context 'but not functional' do
+            let!(:other_idp_enabled) { false }
+
+            it 'includes the original, ignores other' do
+              expect(assigns[:identity_provider_entities])
+                .to include(raw_ed_idp)
+                .and not_include(other_raw_ed_idp)
+            end
+          end
+
+          context 'and is functional' do
+            let!(:other_idp_enabled) { true }
+
+            it 'includes the other, ignores original' do
+              expect(assigns[:identity_provider_entities])
+                .to include(other_raw_ed_idp)
+                .and not_include(raw_ed_idp)
+            end
+          end
+        end
+
+        context 'other has higher rank' do
+          let!(:other_rank) { entity_source.rank + 1 }
+
+          context 'but not functional' do
+            let!(:other_idp_enabled) { false }
+
+            it 'includes the original, ignores other' do
+              expect(assigns[:identity_provider_entities])
+                .to include(raw_ed_idp)
+                .and not_include(other_raw_ed_idp)
+            end
+          end
+
+          context 'and is functional' do
+            let!(:other_idp_enabled) { true }
+
+            it 'includes the original, ignores other' do
+              expect(assigns[:identity_provider_entities])
+                .to include(raw_ed_idp)
+                .and not_include(other_raw_ed_idp)
+            end
+          end
+        end
+      end
+
+      context 'other rad-idp with same entity id as ed-idp' do
+        let!(:other_raw_ed_idp) do
+          other = create(:raw_entity_descriptor_idp,
+                         known_entity: other_idp_known_entity,
+                         enabled: other_idp_enabled,
+                         idp: true)
+          other.entity_id.update(uri: identity_provider.entity_id.uri)
+          other
+        end
+
+        context 'other (rad-idp) has lower rank than ed-idp' do
+          let!(:other_rank) { entity_source.rank - 1 }
+
+          context 'but not functional' do
+            let!(:other_idp_enabled) { false }
+
+            it 'includes ed-idp, ignores rad-idp' do
+              expect(assigns[:identity_provider_entities])
+                .to include(identity_provider)
+                .and not_include(other_raw_ed_idp)
+            end
+          end
+
+          context 'and is functional' do
+            let!(:other_idp_enabled) { true }
+
+            it 'includes the rad-idp, ignores ed-idp' do
+              expect(assigns[:identity_provider_entities])
+                .to include(other_raw_ed_idp)
+                .and not_include(identity_provider)
+            end
+          end
+        end
+
+        context 'other (rad-idp) has higher rank than ed-idp' do
+          let!(:other_rank) { entity_source.rank + 1 }
+
+          context 'but not functional' do
+            let!(:other_idp_enabled) { false }
+
+            it 'includes ed-idp, ignores rad-idp' do
+              expect(assigns[:identity_provider_entities])
+                .to include(identity_provider)
+                .and not_include(other_raw_ed_idp)
+            end
+          end
+
+          context 'and is functional' do
+            let!(:other_idp_enabled) { true }
+
+            it 'includes ed-idp, ignores rad-idp' do
+              expect(assigns[:identity_provider_entities])
+                .to include(raw_ed_idp)
+                .and not_include(other_raw_ed_idp)
+            end
+          end
+        end
       end
     end
 

--- a/spec/controllers/api/discovery_entities_controller_spec.rb
+++ b/spec/controllers/api/discovery_entities_controller_spec.rb
@@ -157,7 +157,7 @@ RSpec.describe API::DiscoveryEntitiesController, type: :controller do
           context 'but not functional' do
             let!(:other_idp_enabled) { false }
 
-            it 'includes the original, ignores other' do
+            it 'includes existing, ignores other' do
               expect(assigns[:identity_provider_entities])
                 .to include(identity_provider)
                 .and not_include(other_identity_provider)
@@ -167,7 +167,7 @@ RSpec.describe API::DiscoveryEntitiesController, type: :controller do
           context 'and is functional' do
             let!(:other_idp_enabled) { true }
 
-            it 'includes the other, ignores original' do
+            it 'includes other, ignores existing' do
               expect(assigns[:identity_provider_entities])
                 .to include(other_identity_provider)
                 .and not_include(identity_provider)
@@ -181,7 +181,7 @@ RSpec.describe API::DiscoveryEntitiesController, type: :controller do
           context 'but not functional' do
             let!(:other_idp_enabled) { false }
 
-            it 'includes the original, ignores other' do
+            it 'includes existing, ignores other' do
               expect(assigns[:identity_provider_entities])
                 .to include(identity_provider)
                 .and not_include(other_identity_provider)
@@ -191,7 +191,7 @@ RSpec.describe API::DiscoveryEntitiesController, type: :controller do
           context 'and is functional' do
             let!(:other_idp_enabled) { true }
 
-            it 'includes the original, ignores other' do
+            it 'includes existing, ignores other' do
               expect(assigns[:identity_provider_entities])
                 .to include(identity_provider)
                 .and not_include(other_identity_provider)
@@ -216,7 +216,7 @@ RSpec.describe API::DiscoveryEntitiesController, type: :controller do
           context 'but not functional' do
             let!(:other_idp_enabled) { false }
 
-            it 'includes the original, ignores other' do
+            it 'includes existing, ignores other' do
               expect(assigns[:identity_provider_entities])
                 .to include(raw_ed_idp)
                 .and not_include(other_raw_ed_idp)
@@ -226,7 +226,7 @@ RSpec.describe API::DiscoveryEntitiesController, type: :controller do
           context 'and is functional' do
             let!(:other_idp_enabled) { true }
 
-            it 'includes the other, ignores original' do
+            it 'includes other, ignores existing' do
               expect(assigns[:identity_provider_entities])
                 .to include(other_raw_ed_idp)
                 .and not_include(raw_ed_idp)
@@ -240,7 +240,7 @@ RSpec.describe API::DiscoveryEntitiesController, type: :controller do
           context 'but not functional' do
             let!(:other_idp_enabled) { false }
 
-            it 'includes the original, ignores other' do
+            it 'includes existing, ignores other' do
               expect(assigns[:identity_provider_entities])
                 .to include(raw_ed_idp)
                 .and not_include(other_raw_ed_idp)
@@ -250,7 +250,7 @@ RSpec.describe API::DiscoveryEntitiesController, type: :controller do
           context 'and is functional' do
             let!(:other_idp_enabled) { true }
 
-            it 'includes the original, ignores other' do
+            it 'includes existing, ignores other' do
               expect(assigns[:identity_provider_entities])
                 .to include(raw_ed_idp)
                 .and not_include(other_raw_ed_idp)
@@ -259,7 +259,7 @@ RSpec.describe API::DiscoveryEntitiesController, type: :controller do
         end
       end
 
-      context 'other rad-idp with same entity id as ed-idp' do
+      context 'rad-idp with same entity id as ed-idp' do
         let!(:other_raw_ed_idp) do
           other = create(:raw_entity_descriptor_idp,
                          known_entity: other_idp_known_entity,
@@ -269,10 +269,10 @@ RSpec.describe API::DiscoveryEntitiesController, type: :controller do
           other
         end
 
-        context 'other (rad-idp) has lower rank than ed-idp' do
+        context 'rad-idp has lower rank than ed-idp' do
           let!(:other_rank) { entity_source.rank - 1 }
 
-          context 'but not functional' do
+          context 'but rad-idp not functional' do
             let!(:other_idp_enabled) { false }
 
             it 'includes ed-idp, ignores rad-idp' do
@@ -282,10 +282,10 @@ RSpec.describe API::DiscoveryEntitiesController, type: :controller do
             end
           end
 
-          context 'and is functional' do
+          context 'and rad-idp is functional' do
             let!(:other_idp_enabled) { true }
 
-            it 'includes the rad-idp, ignores ed-idp' do
+            it 'includes rad-idp, ignores ed-idp' do
               expect(assigns[:identity_provider_entities])
                 .to include(other_raw_ed_idp)
                 .and not_include(identity_provider)
@@ -293,10 +293,10 @@ RSpec.describe API::DiscoveryEntitiesController, type: :controller do
           end
         end
 
-        context 'other (rad-idp) has higher rank than ed-idp' do
+        context 'rad-idp has higher rank than ed-idp' do
           let!(:other_rank) { entity_source.rank + 1 }
 
-          context 'but not functional' do
+          context 'but rad-idp not functional' do
             let!(:other_idp_enabled) { false }
 
             it 'includes ed-idp, ignores rad-idp' do
@@ -306,7 +306,7 @@ RSpec.describe API::DiscoveryEntitiesController, type: :controller do
             end
           end
 
-          context 'and is functional' do
+          context 'and rad-idp is functional' do
             let!(:other_idp_enabled) { true }
 
             it 'includes ed-idp, ignores rad-idp' do
@@ -338,17 +338,17 @@ RSpec.describe API::DiscoveryEntitiesController, type: :controller do
           context 'but not functional' do
             let!(:other_sp_enabled) { false }
 
-            it 'includes the original, ignores other' do
+            it 'includes existing, ignores other' do
               expect(assigns[:service_provider_entities])
                 .to include(service_provider)
                 .and not_include(other_service_provider)
             end
           end
 
-          context 'and is functional' do
+          context 'and other is functional' do
             let!(:other_sp_enabled) { true }
 
-            it 'includes the other, ignores original' do
+            it 'includes other, ignores existing' do
               expect(assigns[:service_provider_entities])
                 .to include(other_service_provider)
                 .and not_include(service_provider)
@@ -362,7 +362,7 @@ RSpec.describe API::DiscoveryEntitiesController, type: :controller do
           context 'but not functional' do
             let!(:other_sp_enabled) { false }
 
-            it 'includes the original, ignores other' do
+            it 'includes existing, ignores other' do
               expect(assigns[:service_provider_entities])
                 .to include(service_provider)
                 .and not_include(other_service_provider)
@@ -372,7 +372,7 @@ RSpec.describe API::DiscoveryEntitiesController, type: :controller do
           context 'and is functional' do
             let!(:other_sp_enabled) { true }
 
-            it 'includes the original, ignores other' do
+            it 'includes existing, ignores other' do
               expect(assigns[:service_provider_entities])
                 .to include(service_provider)
                 .and not_include(other_service_provider)
@@ -397,7 +397,7 @@ RSpec.describe API::DiscoveryEntitiesController, type: :controller do
           context 'but not functional' do
             let!(:other_sp_enabled) { false }
 
-            it 'includes the original, ignores other' do
+            it 'includes existing, ignores other' do
               expect(assigns[:service_provider_entities])
                 .to include(raw_ed_sp)
                 .and not_include(other_raw_ed_sp)
@@ -407,7 +407,7 @@ RSpec.describe API::DiscoveryEntitiesController, type: :controller do
           context 'and is functional' do
             let!(:other_sp_enabled) { true }
 
-            it 'includes the other, ignores original' do
+            it 'includes other, ignores existing' do
               expect(assigns[:service_provider_entities])
                 .to include(other_raw_ed_sp)
                 .and not_include(raw_ed_sp)
@@ -421,7 +421,7 @@ RSpec.describe API::DiscoveryEntitiesController, type: :controller do
           context 'but not functional' do
             let!(:other_sp_enabled) { false }
 
-            it 'includes the original, ignores other' do
+            it 'includes existing, ignores other' do
               expect(assigns[:service_provider_entities])
                 .to include(raw_ed_sp)
                 .and not_include(other_raw_ed_sp)
@@ -431,7 +431,7 @@ RSpec.describe API::DiscoveryEntitiesController, type: :controller do
           context 'and is functional' do
             let!(:other_sp_enabled) { true }
 
-            it 'includes the original, ignores other' do
+            it 'includes existing, ignores other' do
               expect(assigns[:service_provider_entities])
                 .to include(raw_ed_sp)
                 .and not_include(other_raw_ed_sp)
@@ -450,7 +450,7 @@ RSpec.describe API::DiscoveryEntitiesController, type: :controller do
           other
         end
 
-        context 'other (rad-sp) has lower rank than ed-sp' do
+        context 'rad-sp has lower rank than ed-sp' do
           let!(:other_rank) { entity_source.rank - 1 }
 
           context 'but not functional' do
@@ -466,7 +466,7 @@ RSpec.describe API::DiscoveryEntitiesController, type: :controller do
           context 'and is functional' do
             let!(:other_sp_enabled) { true }
 
-            it 'includes the rad-sp, ignores ed-sp' do
+            it 'includes rad-sp, ignores ed-sp' do
               expect(assigns[:service_provider_entities])
                 .to include(other_raw_ed_sp)
                 .and not_include(service_provider)
@@ -474,7 +474,7 @@ RSpec.describe API::DiscoveryEntitiesController, type: :controller do
           end
         end
 
-        context 'other (rad-sp) has higher rank than ed-sp' do
+        context 'rad-sp has higher rank than ed-sp' do
           let!(:other_rank) { entity_source.rank + 1 }
 
           context 'but not functional' do

--- a/spec/models/known_entity_spec.rb
+++ b/spec/models/known_entity_spec.rb
@@ -341,4 +341,46 @@ RSpec.describe KnownEntity do
       end
     end
   end
+
+  describe '#functioning_entity' do
+    subject { entity.functioning_entity }
+
+    context 'as entity descriptor' do
+      let(:entity) { create(:known_entity, :with_idp, enabled: enabled) }
+
+      before { entity.entity_descriptor.update(enabled: enabled) }
+
+      context 'non functioning' do
+        let(:enabled) { false }
+
+        it { is_expected.to be_nil }
+      end
+
+      context 'functioning' do
+        let(:enabled) { true }
+
+        it { is_expected.to eq(entity.entity_descriptor) }
+      end
+    end
+
+    context 'as raw entity descriptor' do
+      let(:entity) do
+        create(:known_entity, :with_raw_entity_descriptor, enabled: enabled)
+      end
+
+      before { entity.raw_entity_descriptor.update(enabled: enabled) }
+
+      context 'non functioning' do
+        let(:enabled) { false }
+
+        it { is_expected.to be_nil }
+      end
+
+      context 'functioning' do
+        let(:enabled) { true }
+
+        it { is_expected.to eq(entity.raw_entity_descriptor) }
+      end
+    end
+  end
 end


### PR DESCRIPTION
See https://github.com/ausaccessfed/saml-service/pull/163. This change needs to also be applied to our discovery endpoints too. Currently DS is showing two entries for Swinburne IdP, because it exists in hosted-idp-service and FR.

Tests might be overkill, I wasn't sure how / if Entity ID uniqueness was enforced with entity descriptors and raw entity descriptors. 

Works with https://github.com/ausaccessfed/aaf-ansible/pull/516.