### PR TITLE
Bugfix/discovery api non functioning entities

### DIFF
--- a/app/controllers/api/discovery_entities_controller.rb
+++ b/app/controllers/api/discovery_entities_controller.rb
@@ -56,6 +56,7 @@ module API
       entities.collect(&:known_entity)
               .group_by(&:entity_id)
               .map { |_, es| functioning_entity(order_by_rank(es)) }
+              .compact
     end
 
     def order_by_rank(known_entities)

--- a/spec/controllers/api/discovery_entities_controller_spec.rb
+++ b/spec/controllers/api/discovery_entities_controller_spec.rb
@@ -80,6 +80,11 @@ RSpec.describe API::DiscoveryEntitiesController, type: :controller do
         expect(assigns[:identity_provider_entities])
           .not_to include(identity_provider)
       end
+
+      it 'has no nil values' do
+        expect(assigns[:identity_provider_entities])
+          .not_to include(nil)
+      end
     end
 
     context 'for a disabled raw entity descriptor - idp' do
@@ -90,6 +95,11 @@ RSpec.describe API::DiscoveryEntitiesController, type: :controller do
       it 'excludes the identity provider' do
         expect(assigns[:identity_provider_entities])
           .not_to include(raw_ed_idp)
+      end
+
+      it 'has no nil values' do
+        expect(assigns[:identity_provider_entities])
+          .not_to include(nil)
       end
     end
 
@@ -108,6 +118,11 @@ RSpec.describe API::DiscoveryEntitiesController, type: :controller do
         expect(assigns[:service_provider_entities])
           .not_to include(service_provider)
       end
+
+      it 'has no nil values' do
+        expect(assigns[:service_provider_entities])
+          .not_to include(nil)
+      end
     end
 
     context 'for a disabled raw entity descriptor - sp' do
@@ -118,6 +133,11 @@ RSpec.describe API::DiscoveryEntitiesController, type: :controller do
       it 'excludes the service provider' do
         expect(assigns[:service_provider_entities])
           .not_to include(raw_ed_sp)
+      end
+
+      it 'has no nil values' do
+        expect(assigns[:service_provider_entities])
+          .not_to include(nil)
       end
     end
 

--- a/spec/controllers/api/discovery_entities_controller_spec.rb
+++ b/spec/controllers/api/discovery_entities_controller_spec.rb
@@ -492,7 +492,7 @@ RSpec.describe API::DiscoveryEntitiesController, type: :controller do
 
             it 'includes ed-sp, ignores rad-sp' do
               expect(assigns[:service_provider_entities])
-                .to include(raw_ed_sp)
+                .to include(service_provider)
                 .and not_include(other_raw_ed_sp)
             end
           end


### PR DESCRIPTION
`DiscoveryEntitiesController` is returns a `nil` per entity if it is not functioning. This PR removes these values.