### PR TITLE
Ingest security contacts from Federation Registry

### DIFF
--- a/app/models/entity_descriptor.rb
+++ b/app/models/entity_descriptor.rb
@@ -6,6 +6,7 @@ class EntityDescriptor < Sequel::Model
 
   one_to_many :additional_metadata_locations
   one_to_many :contact_people
+  one_to_many :sirtfi_contact_people
   one_to_many :role_descriptors
   one_to_many :idp_sso_descriptors
   one_to_many :sp_sso_descriptors

--- a/app/models/role_descriptor.rb
+++ b/app/models/role_descriptor.rb
@@ -7,6 +7,7 @@ class RoleDescriptor < Sequel::Model
   one_to_many :protocol_supports
   one_to_many :key_descriptors
   one_to_many :contact_people
+  one_to_many :sirtfi_contact_people
   one_to_many :scopes, class: 'SHIBMD::Scope'
 
   one_to_one :ui_info, class: 'MDUI::UIInfo'

--- a/app/models/sirtfi_contact_person.rb
+++ b/app/models/sirtfi_contact_person.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class SIRTFIContactPerson < Sequel::Model
+  many_to_one :contact
+  many_to_one :entity_descriptor
+  many_to_one :role_descriptor
+
+  def validate
+    super
+    validates_presence %i[contact created_at updated_at]
+  end
+end

--- a/config/initializers/inflections.rb
+++ b/config/initializers/inflections.rb
@@ -24,4 +24,5 @@ ActiveSupport::Inflector.inflections(:en) do |inflect|
   inflect.acronym 'MDRPI'
   inflect.acronym 'MDATTR'
   inflect.acronym 'API'
+  inflect.acronym 'SIRTFI'
 end

--- a/db/migrate/20170803002700_create_sirtfi_contact_people.rb
+++ b/db/migrate/20170803002700_create_sirtfi_contact_people.rb
@@ -3,11 +3,11 @@ Sequel.migration do
     create_table :sirtfi_contact_people do
       primary_key :id
       foreign_key :contact_id, :contacts, null: false,
-                  foreign_key_constraint_name: 'contact_fkey'
+                  foreign_key_constraint_name: 'sirtfi_contact_fkey'
       foreign_key :entity_descriptor_id, :entity_descriptors,
-                  foreign_key_constraint_name: 'ed_cp_fkey'
+                  foreign_key_constraint_name: 'sirtfi_ed_cp_fkey'
       foreign_key :role_descriptor_id, :role_descriptors,
-                  foreign_key_constraint_name: 'rd_cp_fkey'
+                  foreign_key_constraint_name: 'sirtfi_rd_cp_fkey'
 
       String :extensions, text: true
 

--- a/db/migrate/20170803002700_create_sirtfi_contact_people.rb
+++ b/db/migrate/20170803002700_create_sirtfi_contact_people.rb
@@ -1,0 +1,18 @@
+Sequel.migration do
+  change do
+    create_table :sirtfi_contact_people do
+      primary_key :id
+      foreign_key :contact_id, :contacts, null: false,
+                  foreign_key_constraint_name: 'contact_fkey'
+      foreign_key :entity_descriptor_id, :entity_descriptors,
+                  foreign_key_constraint_name: 'ed_cp_fkey'
+      foreign_key :role_descriptor_id, :role_descriptors,
+                  foreign_key_constraint_name: 'rd_cp_fkey'
+
+      String :extensions, text: true
+
+      DateTime :created_at
+      DateTime :updated_at
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -556,6 +556,20 @@ Sequel.migration do
       index [:idp_sso_descriptor_id], :name=>:idp_ssos_fkey
     end
     
+    create_table(:sirtfi_contact_people) do
+      primary_key :id, :type=>"int(11)"
+      foreign_key :contact_id, :contacts, :type=>"int(11)", :null=>false, :key=>[:id]
+      foreign_key :entity_descriptor_id, :entity_descriptors, :type=>"int(11)", :key=>[:id]
+      foreign_key :role_descriptor_id, :role_descriptors, :type=>"int(11)", :key=>[:id]
+      column :extensions, "text"
+      column :created_at, "datetime"
+      column :updated_at, "datetime"
+      
+      index [:contact_id], :name=>:contact_fkey
+      index [:entity_descriptor_id], :name=>:ed_cp_fkey
+      index [:role_descriptor_id], :name=>:rd_cp_fkey
+    end
+    
     create_table(:ui_infos) do
       primary_key :id, :type=>"int(11)"
       foreign_key :role_descriptor_id, :role_descriptors, :type=>"int(11)", :null=>false, :key=>[:id]
@@ -876,5 +890,6 @@ self << "INSERT INTO `schema_migrations` (`filename`) VALUES ('20170616045451_ad
 self << "INSERT INTO `schema_migrations` (`filename`) VALUES ('20170619194544_create_derived_tags.rb')"
 self << "INSERT INTO `schema_migrations` (`filename`) VALUES ('20170802213241_make_key_type_id_nullable.rb')"
 self << "INSERT INTO `schema_migrations` (`filename`) VALUES ('20170802230844_allow_larger_rank_values.rb')"
+self << "INSERT INTO `schema_migrations` (`filename`) VALUES ('20170803002700_create_sirtfi_contact_people.rb')"
                 end
               end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -565,9 +565,9 @@ Sequel.migration do
       column :created_at, "datetime"
       column :updated_at, "datetime"
       
-      index [:contact_id], :name=>:contact_fkey
-      index [:entity_descriptor_id], :name=>:ed_cp_fkey
-      index [:role_descriptor_id], :name=>:rd_cp_fkey
+      index [:contact_id], :name=>:sirtfi_contact_fkey
+      index [:entity_descriptor_id], :name=>:sirtfi_ed_cp_fkey
+      index [:role_descriptor_id], :name=>:sirtfi_rd_cp_fkey
     end
     
     create_table(:ui_infos) do

--- a/lib/tasks/xsd.rake
+++ b/lib/tasks/xsd.rake
@@ -51,7 +51,10 @@ namespace :xsd do
     'http://docs.oasis-open.org/wsfed/federation/v1.2/os/ws-federation.xsd',
 
     'schema/ws-privacy.xsd' =>
-    'http://docs.oasis-open.org/wsfed/authorization/v1.2/os/ws-authorization.xsd'
+    'http://docs.oasis-open.org/wsfed/authorization/v1.2/os/ws-authorization.xsd',
+
+    'schema/refeds_metadata_extension_schema.xsd' =>
+    'https://s3-ap-southeast-2.amazonaws.com/aaf-binaries/schema/refeds_metadata_extension_schema.xsd'
   }
 
   task all: schemas.keys

--- a/schema/top.xsd
+++ b/schema/top.xsd
@@ -13,6 +13,9 @@
   <import namespace="urn:oasis:names:tc:SAML:metadata:attribute" schemaLocation="sstc-metadata-attr.xsd"/>
   <import namespace="urn:oasis:names:tc:SAML:profiles:SSO:idp-discovery-protocol" schemaLocation="sstc-saml-idp-discovery.xsd"/>
 
+  <!-- SIRTFI contact support -->
+  <import namespace="http://refeds.org/metadata" schemaLocation="refeds_metadata_extension_schema.xsd"/>
+
   <!-- WS Fed support, due to usage in wider eduGAIN supplied ED -->
   <import namespace="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd" schemaLocation="oasis-200401-wss-wssecurity-utility-1.0.xsd" />
   <import namespace="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd" schemaLocation="oasis-200401-wss-wssecurity-secext-1.0.xsd" />

--- a/spec/models/sirtfi_contact_person_spec.rb
+++ b/spec/models/sirtfi_contact_person_spec.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe SIRTFIContactPerson do
+  it_behaves_like 'a basic model'
+
+  it { is_expected.to validate_presence(:contact) }
+end

--- a/spec/support/jobs/concerns/etl/common.rb
+++ b/spec/support/jobs/concerns/etl/common.rb
@@ -40,13 +40,24 @@ RSpec.shared_examples 'ETL::Common' do
     }
   end
 
-  def contact_person_json(cp)
+  def contact_person_json(contact)
     {
       type: {
         name: ContactPerson::TYPE.keys[rand 0..4].to_s
       },
       contact: {
-        id: cp.id
+        id: contact.id
+      }
+    }
+  end
+
+  def sirtfi_contact_person_json(contact)
+    {
+      type: {
+        name: 'Security'
+      },
+      contact: {
+        id: contact.id
       }
     }
   end
@@ -92,9 +103,16 @@ RSpec.shared_examples 'ETL::Common' do
   let(:contact_instances) do
     create_list(:contact, contact_count)
   end
-  let(:contacts_list) do
-    contact_instances.map { |ci| contact_json(ci) }
+
+  let(:sirtfi_contact_instances) do
+    create_list(:contact, sirtfi_contact_count)
   end
+
+  let(:contacts_list) do
+    [*contact_instances, *sirtfi_contact_instances]
+      .map { |ci| contact_json(ci) }
+  end
+
   let(:contacts) { contacts_list }
 
   shared_examples 'saml_attributes' do
@@ -140,6 +158,11 @@ RSpec.shared_examples 'ETL::Common' do
     it 'updates contact people' do
       expect { run }
         .to(change { subject.entity_descriptor.reload.contact_people })
+    end
+
+    it 'updates sirtfi contact people' do
+      expect { run }
+        .to(change { subject.entity_descriptor.reload.sirtfi_contact_people })
     end
 
     it 'updates protocol supports' do

--- a/spec/support/jobs/concerns/etl/contacts.rb
+++ b/spec/support/jobs/concerns/etl/contacts.rb
@@ -15,7 +15,8 @@ RSpec.shared_examples 'ETL::Contacts' do
 
   let(:contact_created_at) { Time.zone.at(rand(Time.now.utc.to_i)) }
   let(:contact_list) do
-    (0...contact_count).reduce([]) { |a, e| a << create_json(1000 + e) }
+    total = contact_count + sirtfi_contact_count
+    (0...total).reduce([]) { |a, e| a << create_json(1000 + e) }
   end
 
   before do
@@ -29,6 +30,7 @@ RSpec.shared_examples 'ETL::Contacts' do
   context 'creating a contact' do
     let(:contacts) { contact_list }
     let(:contact_count) { 1 }
+    let(:sirtfi_contact_count) { 1 }
     before { run }
     subject { Contact.last }
 
@@ -63,26 +65,31 @@ RSpec.shared_examples 'ETL::Contacts' do
 
     shared_examples 'obj creation' do
       it 'creates contact' do
-        expect { run }.to change { Contact.count }.by(contact_count)
+        expect { run }.to change { Contact.count }
+          .by(contact_count + sirtfi_contact_count)
       end
     end
 
     context 'single new contact' do
       let(:contact_count) { 1 }
+      let(:sirtfi_contact_count) { 1 }
       include_examples 'obj creation'
     end
 
     context 'multiple new contacts' do
       let(:contact_count) { rand(2..20) }
+      let(:sirtfi_contact_count) { rand(2..20) }
       include_examples 'obj creation'
     end
 
     context 'updating contacts' do
       let(:contact_count) { 1 }
+      let(:sirtfi_contact_count) { 1 }
       before { run }
 
       context 'subsequent requests' do
         let(:contact_count) { 0 }
+        let(:sirtfi_contact_count) { 0 }
         before { run }
         include_examples 'obj creation'
       end


### PR DESCRIPTION
This ingests the security contacts required for SIRTFI, but doesn't (yet) publish them in metadata.

These contacts are held in a separate model, because they need to be rendered differently in the output metadata.