### PR TITLE
Publish SIRTFI contact in metadata

### DIFF
--- a/lib/metadata/saml.rb
+++ b/lib/metadata/saml.rb
@@ -270,6 +270,14 @@ module Metadata
         contact_people.each do |cp|
           contact_person(cp)
         end
+
+        sirtfi_contact_people = ed.sirtfi_contact_people do |ds|
+          ds.order(:contact_id)
+        end
+
+        sirtfi_contact_people.each do |cp|
+          sirtfi_contact_person(cp)
+        end
       end
     end
 
@@ -313,6 +321,24 @@ module Metadata
 
     def contact_person(cp)
       attributes = { contactType: cp.contact_type }
+      c = cp.contact
+      root.ContactPerson(ns, attributes) do |_|
+        root.Company(c.company) if c.company.present?
+        root.GivenName(c.given_name) if c.given_name.present?
+        root.SurName(c.surname) if c.surname.present?
+        if c.email_address.present?
+          root.EmailAddress("mailto:#{c.email_address}")
+        end
+        root.TelephoneNumber(c.telephone_number) if c.telephone_number.present?
+      end
+    end
+
+    def sirtfi_contact_person(cp)
+      attributes = {
+        contactType: 'other',
+        'remd:contactType': 'http://refeds.org/metadata/contactType/security'
+      }
+
       c = cp.contact
       root.ContactPerson(ns, attributes) do |_|
         root.Company(c.company) if c.company.present?

--- a/lib/metadata/saml_namespaces.rb
+++ b/lib/metadata/saml_namespaces.rb
@@ -14,7 +14,8 @@ module Metadata
       'xmlns:ds' => 'http://www.w3.org/2000/09/xmldsig#',
       'xmlns:xsi' => 'http://www.w3.org/2001/XMLSchema-instance',
       'xmlns:fed' => 'http://docs.oasis-open.org/wsfed/federation/200706',
-      'xmlns:privacy' => 'http://docs.oasis-open.org/wsfed/privacy/200706'
+      'xmlns:privacy' => 'http://docs.oasis-open.org/wsfed/privacy/200706',
+      'xmlns:remd' => 'http://refeds.org/metadata'
     }.freeze
 
     def root

--- a/spec/factories/sirtfi_contact_people.rb
+++ b/spec/factories/sirtfi_contact_people.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+FactoryGirl.define do
+  factory :sirtfi_contact_person do
+    association :contact
+
+    trait :without_company do
+      association :contact, company: nil
+    end
+    trait :without_given_name do
+      association :contact, given_name: nil
+    end
+    trait :without_surname do
+      association :contact, surname: nil
+    end
+    trait :without_email_address do
+      association :contact, email_address: nil
+    end
+    trait :without_telephone_number do
+      association :contact, telephone_number: nil
+    end
+  end
+end

--- a/spec/metadata/saml_spec.rb
+++ b/spec/metadata/saml_spec.rb
@@ -206,6 +206,12 @@ RSpec.describe Metadata::SAML do
     include_examples 'ContactPerson xml'
   end
 
+  context 'SIRTFI ContactPersons' do
+    let(:sirtfi_contact_person) { create(:sirtfi_contact_person) }
+    before { subject.sirtfi_contact_person(sirtfi_contact_person) }
+    include_examples 'SIRTFI ContactPerson xml'
+  end
+
   context 'EntityAttributes' do
     let(:entity_attribute) { create :mdattr_entity_attribute }
     before { subject.entity_attribute(entity_attribute) }

--- a/spec/support/metadata/saml_namespaces.rb
+++ b/spec/support/metadata/saml_namespaces.rb
@@ -16,9 +16,9 @@ RSpec.shared_examples 'SAML namespaces' do
     it { is_expected.to respond_to(:ds) }
     it { is_expected.to respond_to(:ns) }
 
-    it 'has 11 namespaces defined' do
-      expect(subject.ns.size).to eq(11)
-      expect(Metadata::SAMLNamespaces::NAMESPACES.size).to eq(11)
+    it 'has 12 namespaces defined' do
+      expect(subject.ns.size).to eq(12)
+      expect(Metadata::SAMLNamespaces::NAMESPACES.size).to eq(12)
     end
 
     let(:ns) { subject.ns }
@@ -56,6 +56,9 @@ RSpec.shared_examples 'SAML namespaces' do
     end
     it 'supports SAML 2.0 assertion' do
       expect(ns['xmlns:privacy']).to eq('http://docs.oasis-open.org/wsfed/privacy/200706')
+    end
+    it 'supports REFEDS metadata extension schema' do
+      expect(ns['xmlns:remd']).to eq('http://refeds.org/metadata')
     end
   end
 end

--- a/spec/support/metadata/sirtfi_contact_person.rb
+++ b/spec/support/metadata/sirtfi_contact_person.rb
@@ -1,0 +1,132 @@
+# frozen_string_literal: true
+
+RSpec.shared_examples 'SIRTFI ContactPerson xml' do
+  let(:contact_person_path) { '/ContactPerson' }
+  let(:contact_person_company_path) { "#{contact_person_path}/Company" }
+  let(:contact_person_given_name_path) { "#{contact_person_path}/GivenName" }
+  let(:contact_person_surname_path) { "#{contact_person_path}/SurName" }
+  let(:contact_person_email_address_path) do
+    "#{contact_person_path}/EmailAddress"
+  end
+  let(:contact_person_telephone_number_path) do
+    "#{contact_person_path}/TelephoneNumber"
+  end
+  let(:node) { xml.first(:xpath, contact_person_path) }
+
+  it 'is created' do
+    expect(xml).to have_xpath(contact_person_path, count: 1)
+  end
+
+  context 'attributes' do
+    it 'sets contactType' do
+      expect(node['contactType']).to eq('other')
+    end
+
+    it 'sets remd:contactType' do
+      expect(node['remd:contactType'])
+        .to eq('http://refeds.org/metadata/contactType/security')
+    end
+  end
+
+  context 'Company' do
+    let(:node) { xml.first(:xpath, contact_person_company_path) }
+    context 'when unknown' do
+      let(:sirtfi_contact_person) do
+        create :sirtfi_contact_person, :without_company
+      end
+      it 'is not created' do
+        expect(xml).not_to have_xpath(contact_person_company_path)
+      end
+    end
+    context 'when known' do
+      it 'is created' do
+        expect(xml).to have_xpath(contact_person_company_path, count: 1)
+      end
+      it 'has correct value' do
+        expect(node.text).to eq(sirtfi_contact_person.contact.company)
+      end
+    end
+  end
+
+  context 'GivenName' do
+    let(:node) { xml.first(:xpath, contact_person_given_name_path) }
+    context 'when unknown' do
+      let(:sirtfi_contact_person) do
+        create :sirtfi_contact_person, :without_given_name
+      end
+      it 'is not created' do
+        expect(xml).not_to have_xpath(contact_person_given_name_path)
+      end
+    end
+    context 'when known' do
+      it 'is created' do
+        expect(xml).to have_xpath(contact_person_given_name_path, count: 1)
+      end
+      it 'has correct value' do
+        expect(node.text).to eq(sirtfi_contact_person.contact.given_name)
+      end
+    end
+  end
+
+  context 'Surname' do
+    let(:node) { xml.first(:xpath, contact_person_surname_path) }
+    context 'when unknown' do
+      let(:sirtfi_contact_person) do
+        create :sirtfi_contact_person, :without_surname
+      end
+      it 'is not created' do
+        expect(xml).not_to have_xpath(contact_person_surname_path)
+      end
+    end
+    context 'when known' do
+      it 'is created' do
+        expect(xml).to have_xpath(contact_person_surname_path, count: 1)
+      end
+      it 'has correct value' do
+        expect(node.text).to eq(sirtfi_contact_person.contact.surname)
+      end
+    end
+  end
+
+  context 'EmailAddress' do
+    let(:node) { xml.first(:xpath, contact_person_email_address_path) }
+    context 'when unknown' do
+      let(:sirtfi_contact_person) do
+        create :sirtfi_contact_person, :without_email_address
+      end
+      it 'is not created' do
+        expect(xml).not_to have_xpath(contact_person_email_address_path)
+      end
+    end
+    context 'when known' do
+      it 'is created' do
+        expect(xml).to have_xpath(contact_person_email_address_path, count: 1)
+      end
+      it 'has correct value with uri prepended' do
+        expect(node.text)
+          .to eq("mailto:#{sirtfi_contact_person.contact.email_address}")
+      end
+    end
+  end
+
+  context 'TelephoneNumber' do
+    let(:node) { xml.first(:xpath, contact_person_telephone_number_path) }
+    context 'when unknown' do
+      let(:sirtfi_contact_person) do
+        create :sirtfi_contact_person, :without_telephone_number
+      end
+      it 'is not created' do
+        expect(xml).not_to have_xpath(contact_person_telephone_number_path)
+      end
+    end
+    context 'when known' do
+      it 'is created' do
+        expect(xml)
+          .to have_xpath(contact_person_telephone_number_path, count: 1)
+      end
+      it 'has correct value' do
+        expect(node.text).to eq(sirtfi_contact_person.contact.telephone_number)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Requires the supporting change to metadata distribution code before this can be merged.