### PR TITLE
Add ability to sync to a Git repository

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,6 +28,8 @@ gem 'jbuilder'
 
 gem 'bcrypt', '~> 3.1'
 
+gem 'rugged', require: false
+
 gem 'god', require: false
 gem 'puma', require: false
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -266,7 +266,7 @@ GEM
       ruby-progressbar (~> 1.7)
       unicode-display_width (~> 1.0, >= 1.0.1)
     ruby-progressbar (1.8.1)
-    ruby_dep (1.5.0)
+    ruby_dep (1.3.1)
     rufus-scheduler (3.4.2)
       et-orbi (~> 1.0)
     rugged (0.26.0)
@@ -372,4 +372,4 @@ DEPENDENCIES
   xmldsig
 
 BUNDLED WITH
-   1.15.3
+   1.15.4

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -269,6 +269,7 @@ GEM
     ruby_dep (1.5.0)
     rufus-scheduler (3.4.2)
       et-orbi (~> 1.0)
+    rugged (0.26.0)
     safe_yaml (1.0.4)
     sequel (4.49.0)
     sequel-rails (0.9.17)
@@ -359,6 +360,7 @@ DEPENDENCIES
   rspec-retry
   rspec_sequel_matchers!
   rubocop
+  rugged
   sequel
   sequel-rails
   shoulda-matchers

--- a/bin/sync_to_git_repository.rb
+++ b/bin/sync_to_git_repository.rb
@@ -42,7 +42,7 @@ class SyncToGitRepository
   end
 
   def sync(ke)
-    encoded_entity_id = Base64.urlsafe_encode64(ke.entity_id, padding: false)
+    encoded_entity_id = Base64.urlsafe_encode64(ke.entity_id).delete('=')
     filename = "entities/#{@md_instance.identifier}-#{encoded_entity_id}.xml"
 
     write_metadata(ke, filename, generate_metadata(ke))

--- a/bin/sync_to_git_repository.rb
+++ b/bin/sync_to_git_repository.rb
@@ -106,11 +106,8 @@ class SyncToGitRepository
   end
 
   def commit(tree, message)
-    author = {
-      name: 'SAML Service',
-      time: Time.now.getlocal,
-      email: 'noreply@aaf.edu.au'
-    }
+    author = { name: 'SAML Service', time: Time.now.getlocal,
+               email: 'noreply@aaf.edu.au' }
 
     Rugged::Commit.create(@repository,
                           tree: tree, message: message,

--- a/bin/sync_to_git_repository.rb
+++ b/bin/sync_to_git_repository.rb
@@ -1,0 +1,110 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require_relative '../config/environment'
+require 'rugged'
+require 'metadata/saml'
+
+class SyncToGitRepository
+  include Metadata::SAMLNamespaces
+
+  def initialize(args)
+    if args.length != 2
+      $stderr.puts("usage: #{$PROGRAM_NAME} md_instance_identifier " \
+                   '/path/to/git/repository')
+      exit 1
+    end
+
+    instance_identifier, repository_path = args
+    @md_instance = MetadataInstance[identifier: instance_identifier]
+    @repository = Rugged::Repository.new(repository_path)
+  end
+
+  def perform
+    known_entities = KnownEntity.with_all_tags([@md_instance.primary_tag])
+    touched = known_entities.map { |ke| sync(ke) }
+    sweep(touched)
+  end
+
+  private
+
+  def sync(ke)
+    encoded_entity_id = Base64.urlsafe_encode64(ke.entity_id, padding: false)
+    filename = "entities/#{@md_instance.identifier}-#{encoded_entity_id}.xml"
+
+    write_metadata(ke, filename, generate_metadata(ke))
+
+    filename
+  end
+
+  def sweep(touched)
+    prefix = "entities/#{@md_instance.identifier}-"
+
+    all = @repository.index.map { |e| e[:path] }
+                     .select { |p| p.start_with?(prefix) }
+
+    (all - touched).each { |path| remove_stale(path) }
+  end
+
+  def write_metadata(ke, filename, xml)
+    full_path = File.join(@repository.workdir, filename)
+    File.open(full_path, 'w') { |f| f.write(xml) }
+
+    return if @repository.status(filename).empty?
+
+    commit_changes("[sync] #{ke.entity_id}") do |index|
+      object_id = @repository.write(xml, :blob)
+      index.add(path: filename, oid: object_id, mode: 0o100644)
+    end
+  end
+
+  def generate_metadata(ke)
+    renderer = Metadata::SAML.new(metadata_instance: @md_instance)
+
+    if ke.entity_descriptor.try(:functioning?)
+      renderer.entity_descriptor(ke.entity_descriptor, NAMESPACES)
+    elsif ke.raw_entity_descriptor.try(:functioning?)
+      renderer.raw_entity_descriptor(ke.raw_entity_descriptor, NAMESPACES, true)
+    end
+
+    doc = renderer.builder.doc
+    doc.to_xml(indent: 2)
+  end
+
+  def remove_stale(path)
+    full_path = File.join(@repository.workdir, path)
+    FileUtils.rm_f(full_path)
+
+    commit_changes('[sync] remove stale entity') do |index|
+      index.remove(path)
+    end
+  end
+
+  def commit_changes(message)
+    index = @repository.index
+    index.read_tree(@repository.head.target.tree)
+
+    yield index
+
+    index.write
+
+    tree = index.write_tree(@repository)
+    commit(tree, message)
+  end
+
+  def commit(tree, message)
+    author = {
+      name: 'SAML Service',
+      time: Time.now.getlocal,
+      email: 'noreply@aaf.edu.au'
+    }
+
+    Rugged::Commit.create(@repository,
+                          tree: tree, message: message,
+                          author: author, committer: author,
+                          parents: [@repository.head.target],
+                          update_ref: 'HEAD')
+  end
+end
+
+SyncToGitRepository.new(ARGV).perform if $PROGRAM_NAME == __FILE__

--- a/spec/bin/sync_to_git_repository_spec.rb
+++ b/spec/bin/sync_to_git_repository_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe SyncToGitRepository do
     let(:written_blobs) { {} }
 
     let(:encoded_entity_id) do
-      Base64.urlsafe_encode64(entity.entity_id, padding: false)
+      Base64.urlsafe_encode64(entity.entity_id).delete('=')
     end
 
     let(:path) { Faker::Lorem.words.unshift('').join('/') }

--- a/spec/bin/sync_to_git_repository_spec.rb
+++ b/spec/bin/sync_to_git_repository_spec.rb
@@ -12,9 +12,9 @@ RSpec.describe SyncToGitRepository do
       allow(File).to receive(:open).with(file_path, 'w').and_yield(file)
 
       allow(repo).to receive(:status).with("entities/#{filename}")
-        .and_return(file_status)
+                                     .and_return(file_status)
 
-      allow(repo).to receive(:write).with(anything, :blob) do |content, blob|
+      allow(repo).to receive(:write).with(anything, :blob) do |content, _blob|
         object_id = SecureRandom.urlsafe_base64
         written_blobs[object_id] = content
         object_id
@@ -25,9 +25,9 @@ RSpec.describe SyncToGitRepository do
       allow(Rugged::Commit).to receive(:create) { |*a| commit_spy.create(*a) }
 
       allow(config).to receive(:[]).with("branch.#{branch_name}.remote")
-        .and_return(remote_name)
+                                   .and_return(remote_name)
       allow(config).to receive(:[]).with("branch.#{branch_name}.merge")
-        .and_return(remote_branch)
+                                   .and_return(remote_branch)
     end
 
     let(:written_blobs) { {} }

--- a/spec/bin/sync_to_git_repository_spec.rb
+++ b/spec/bin/sync_to_git_repository_spec.rb
@@ -1,0 +1,160 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require_relative '../../bin/sync_to_git_repository'
+
+RSpec.describe SyncToGitRepository do
+  describe '#perform' do
+    before do
+      entity.tag_as(md_instance.primary_tag)
+
+      allow(Rugged::Repository).to receive(:new).with(path).and_return(repo)
+      allow(File).to receive(:open).with(file_path, 'w').and_yield(file)
+
+      allow(repo).to receive(:status).with("entities/#{filename}")
+        .and_return(file_status)
+
+      allow(repo).to receive(:write).with(anything, :blob) do |content, blob|
+        object_id = SecureRandom.urlsafe_base64
+        written_blobs[object_id] = content
+        object_id
+      end
+
+      allow(index).to receive(:write_tree).with(repo).and_return(new_tree)
+
+      allow(Rugged::Commit).to receive(:create) { |*a| commit_spy.create(*a) }
+    end
+
+    let(:written_blobs) { {} }
+
+    let(:encoded_entity_id) do
+      Base64.urlsafe_encode64(entity.entity_id, padding: false)
+    end
+
+    let(:path) { Faker::Lorem.words.unshift('').join('/') }
+    let(:filename) { "#{md_instance.identifier}-#{encoded_entity_id}.xml" }
+    let(:file_path) { File.join(path, 'entities', filename) }
+    let(:file) { spy(IO) }
+    let(:file_status) { [] }
+    let(:empty) { false }
+    let(:md_instance) { create(:metadata_instance) }
+
+    let(:commit_spy) { class_spy(Rugged::Commit) }
+    let(:index) { spy(Rugged::Index) }
+    let(:head_commit) { double(Rugged::Commit, tree: head_tree) }
+    let(:head_tree) { double(Rugged::Tree) }
+    let(:head) { double(Rugged::Reference, target: head_commit) }
+    let(:new_tree) { double(Rugged::Tree) }
+
+    let(:repo) do
+      double(Rugged::Repository,
+             empty?: empty, index: index, workdir: path, head: head)
+    end
+
+    subject { described_class.new([md_instance.identifier, path]) }
+
+    def run
+      subject.perform
+    end
+
+    def author
+      {
+        name: 'SAML Service',
+        time: Time.now.getlocal,
+        email: 'noreply@aaf.edu.au'
+      }
+    end
+
+    shared_examples 'an updated entity' do
+      it 'writes the file' do
+        run
+        expect(file).to have_received(:write).with(an_instance_of(String))
+      end
+
+      it 'commits the file' do
+        Timecop.freeze do
+          run
+
+          expect(commit_spy).to have_received(:create)
+            .with(repo,
+                  author: author, committer: author, tree: new_tree,
+                  message: "[sync] #{entity.entity_id}", parents: [head_commit],
+                  update_ref: 'HEAD')
+        end
+      end
+    end
+
+    shared_examples 'an up-to-date entity' do
+      it 'makes no commits' do
+        run
+        expect(commit_spy).not_to have_received(:create)
+      end
+    end
+
+    shared_examples 'a removed entity' do
+      it 'commits to remove the file' do
+        Timecop.freeze do
+          run
+
+          expect(index).to have_received(:remove).with(stale)
+
+          expect(commit_spy).to have_received(:create)
+            .with(repo,
+                  author: author, committer: author, tree: new_tree,
+                  message: '[sync] remove stale entity', parents: [head_commit],
+                  update_ref: 'HEAD')
+        end
+      end
+    end
+
+    context 'for a raw entity descriptor' do
+      let(:raw_entity_descriptor) { create(:raw_entity_descriptor) }
+      let!(:entity) { raw_entity_descriptor.known_entity }
+
+      context 'for a new entity' do
+        let(:file_status) { [:worktree_new] }
+        it_behaves_like 'an updated entity'
+      end
+
+      context 'for a changed entity' do
+        let(:file_status) { [:worktree_modified] }
+        it_behaves_like 'an updated entity'
+      end
+
+      context 'for an unchanged entity' do
+        let(:file_status) { [] }
+        it_behaves_like 'an up-to-date entity'
+      end
+
+      context 'for a removed entity' do
+        let(:stale) { "entities/#{md_instance.identifier}-stale-entity.xml" }
+
+        before do
+          allow(index).to receive(:map).and_return([stale])
+        end
+
+        it_behaves_like 'a removed entity'
+      end
+    end
+
+    context 'for an entity descriptor' do
+      let(:entity_descriptor) { create(:entity_descriptor, :with_idp) }
+      let!(:entity) { entity_descriptor.known_entity }
+
+      context 'for a new entity' do
+        let(:file_status) { [:worktree_new] }
+        it_behaves_like 'an updated entity'
+      end
+
+      context 'for a changed entity' do
+        let(:file_status) { [:worktree_modified] }
+        it_behaves_like 'an updated entity'
+      end
+
+      context 'for an unchanged entity' do
+        let(:file_status) { [] }
+        it_behaves_like 'an up-to-date entity'
+      end
+    end
+  end
+end

--- a/spec/support/jobs/concerns/etl/attribute_authorities.rb
+++ b/spec/support/jobs/concerns/etl/attribute_authorities.rb
@@ -278,7 +278,7 @@ RSpec.shared_examples 'ETL::AttributeAuthorities' do
           let(:source) do
             identity_providers
               .first[:saml][:sso_descriptor][:role_descriptor][:contact_people]
-              .reject { |cp| cp.dig(:type, :name) == 'Security' }
+              .reject { |cp| cp[:type][:name] == 'Security' }
           end
         end
       end

--- a/spec/support/jobs/concerns/etl/identity_providers.rb
+++ b/spec/support/jobs/concerns/etl/identity_providers.rb
@@ -253,7 +253,7 @@ RSpec.shared_examples 'ETL::IdentityProviders' do
           let(:source) do
             identity_providers
               .first[:saml][:sso_descriptor][:role_descriptor][:contact_people]
-              .reject { |cp| cp.dig(:type, :name) == 'Security' }
+              .reject { |cp| cp[:type][:name] == 'Security' }
           end
         end
       end

--- a/spec/support/jobs/concerns/etl/service_providers.rb
+++ b/spec/support/jobs/concerns/etl/service_providers.rb
@@ -238,7 +238,7 @@ RSpec.shared_examples 'ETL::ServiceProviders' do
           let(:source) do
             service_providers
               .first[:saml][:sso_descriptor][:role_descriptor][:contact_people]
-              .reject { |cp| cp.dig(:type, :name) == 'Security' }
+              .reject { |cp| cp[:type][:name] == 'Security' }
           end
         end
       end


### PR DESCRIPTION
Not enabled anywhere by default, but accessible as a command-line utility to sync all the entities from a `MetadataInstance` into a designated Git repository.