### PR TITLE
Correctly handle known_entities with no data

### DIFF
--- a/bin/sync_to_git_repository.rb
+++ b/bin/sync_to_git_repository.rb
@@ -42,6 +42,8 @@ class SyncToGitRepository
   end
 
   def sync(ke)
+    return if ke.entity_id.nil?
+
     encoded_entity_id = Base64.urlsafe_encode64(ke.entity_id).delete('=')
     filename = "entities/#{@md_instance.identifier}-#{encoded_entity_id}.xml"
 

--- a/spec/bin/sync_to_git_repository_spec.rb
+++ b/spec/bin/sync_to_git_repository_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe SyncToGitRepository do
     let(:written_blobs) { {} }
 
     let(:encoded_entity_id) do
-      Base64.urlsafe_encode64(entity.entity_id).delete('=')
+      entity.entity_id && Base64.urlsafe_encode64(entity.entity_id).delete('=')
     end
 
     let(:path) { Faker::Lorem.words.unshift('').join('/') }
@@ -193,6 +193,14 @@ RSpec.describe SyncToGitRepository do
       context 'for an unchanged entity' do
         let(:file_status) { [] }
         it_behaves_like 'an up-to-date entity'
+      end
+    end
+
+    context 'for a known entity with no data' do
+      let!(:entity) { create(:known_entity) }
+
+      it 'runs without error' do
+        run
       end
     end
   end


### PR DESCRIPTION
For a long-running saml-service, it's possible for KnownEntity records to exist with no data underneath. They have no impact on the operation of saml-service, but don't work correctly with the Git repository export. This change causes the blank KnownEntity records to be skipped just as they are during metadata generation.