### PR TITLE
Remove KeyName from AAF metadata

### DIFF
--- a/lib/metadata/saml.rb
+++ b/lib/metadata/saml.rb
@@ -185,7 +185,6 @@ module Metadata
 
     def key_info(ki)
       ds.KeyInfo(ns) do |_|
-        ds.KeyName ki.key_name if ki.key_name.present?
         ds.X509Data do |_|
           ds.X509SubjectName ki.subject if ki.subject.present?
           ds.X509Certificate ki.certificate_without_anchors

--- a/spec/support/metadata/key_info.rb
+++ b/spec/support/metadata/key_info.rb
@@ -11,36 +11,6 @@ RSpec.shared_examples 'ds:KeyInfo xml' do
     expect(xml).to have_xpath(key_info_path)
   end
 
-  context 'KeyName' do
-    context 'is set' do
-      let(:key_info) { create :key_info, :with_name }
-      let(:node) { xml.find(:xpath, key_name_path) }
-      it 'is created' do
-        expect(xml).to have_xpath(key_name_path)
-      end
-      it 'has correct value' do
-        expect(node.text).to eq(key_info.key_name)
-      end
-    end
-    context 'is not set' do
-      context 'is blank' do
-        let(:key_info) { create :key_info, key_name: '' }
-
-        it 'is not created' do
-          expect(xml).not_to have_xpath(key_name_path)
-        end
-      end
-
-      context 'is nil' do
-        let(:key_info) { create :key_info, key_name: nil }
-
-        it 'is not created' do
-          expect(xml).not_to have_xpath(key_name_path)
-        end
-      end
-    end
-  end
-
   context 'X509Data' do
     it 'is created' do
       expect(xml).to have_xpath(x509_data_path)


### PR DESCRIPTION
Having reviewed AAF metadata and the associated schema specifications it was determined that KeyName was adding no value and could, under the right conditions, be problematic.

This change will need to be previewed in the AAF test federation for a reasonable amount of time to ensure that no breakage occurs for obscure implementations, however this is not anticipated.