### PR TITLE
Tag / untag known entities as edugain if flag set in RawEntityDescriptor API

### DIFF
--- a/app/controllers/api/raw_entity_descriptors_controller.rb
+++ b/app/controllers/api/raw_entity_descriptors_controller.rb
@@ -68,11 +68,17 @@ module API
     def tag_known_entity(known_entity)
       patch_params[:tags].each { |t| known_entity.tag_as(t) }
       known_entity.tag_as(params[:tag])
+
+      if patch_params[:edugain_enabled]
+        known_entity.tag_as('aaf-edugain-export')
+      else
+        known_entity.untag_as('aaf-edugain-export')
+      end
     end
 
     def patch_params
       params.require(:raw_entity_descriptor)
-            .permit(:xml, :enabled, tags: [])
+            .permit(:xml, :enabled, :edugain_enabled, tags: [])
     end
 
     def entity_id_uri
@@ -80,7 +86,8 @@ module API
     end
 
     def valid_patch_params?
-      patch_params[:tags] && [true, false].include?(patch_params[:enabled])
+      patch_params[:tags] && [true, false].include?(patch_params[:enabled]) &&
+        [true, false].include?(patch_params[:edugain_enabled])
     end
 
     def access_path


### PR DESCRIPTION
To support https://github.com/ausaccessfed/hosted-idp-service/pull/245.

N.B. If this is merged into develop, **we won't be able to provision any Hosted IdP metadata in test**. This is because this change introduces a new required flag to be set in the API request. This shouldn't be a problem as we won't need to spin up any IdPs in test in the short term... If it does become a problem, I can make the flag optional. 

Test IdPs will still be functional — we can still rollout changes for branding/etc if required.

To use this feature (as we are working currently) we need to make a release of SAML service too, as the rest of the provisioning stuff is on master.