### PR TITLE
UsagePolicy is spec optional for PublicationInfo

### DIFF
--- a/app/models/mdrpi/publication_info.rb
+++ b/app/models/mdrpi/publication_info.rb
@@ -16,7 +16,6 @@ module MDRPI
       validates_presence %i[publisher created_at updated_at]
       return if new?
 
-      validates_presence :usage_policies
       single_parent %i[metadata_instance entity_descriptor]
     end
   end

--- a/spec/models/mdrpi/publication_info_spec.rb
+++ b/spec/models/mdrpi/publication_info_spec.rb
@@ -11,11 +11,6 @@ RSpec.describe MDRPI::PublicationInfo, type: :model do
 
   it { is_expected.to validate_presence :publisher }
 
-  context 'usage policies' do
-    let(:subject) { create :mdrpi_publication_info }
-    it { is_expected.to validate_presence :usage_policies }
-  end
-
   context 'ownership' do
     let(:subject) { create :mdrpi_publication_info }
 


### PR DESCRIPTION
The AAF will advantage of this by no longer utilising the `UsagePolicy` element when publishing `PublicationInfo` elements in metadata, per the lead taken by other notable federations.

http://docs.oasis-open.org/security/saml/Post2.0/saml-metadata-rpi/v1.0/cs01/saml-metadata-rpi-v1.0-cs01.pdf `section 2.2.1`