### PR TITLE
No longer set or update usage_policy uri

### DIFF
--- a/bin/configure.rb
+++ b/bin/configure.rb
@@ -94,7 +94,6 @@ class ConfigureCLI < Thor
   option :hash, desc: 'The hash algorithm for signing (default: SHA256)',
                 default: 'SHA256'
   option :publisher, desc: 'The URI for MDRPI::PublicationInfo/@publisher'
-  option :usage_policy, desc: 'The URI for MDRPI::UsagePolicy'
   option :lang, desc: 'The specified language for any localised elements'
   long_desc <<-LONGDESC
     Configures the SAML Service with a metadata instance which will be used to
@@ -158,18 +157,6 @@ class ConfigureCLI < Thor
   def update_publication_info(instance)
     pi = instance.publication_info || MDRPI::PublicationInfo.new
     pi.update(publisher: options[:publisher], metadata_instance_id: instance.id)
-
-    update_usage_policy(pi)
-  end
-
-  def update_usage_policy(publication_info)
-    up, up2 = publication_info.usage_policies
-    up ||= MDRPI::UsagePolicy.new
-
-    up2 && raise("Can't PublicationInfo with multiple usage policies")
-
-    up.update(uri: options[:usage_policy], lang: options[:lang],
-              publication_info_id: publication_info.id)
   end
 end
 # rubocop:enable ClassLength

--- a/spec/bin/configure_spec.rb
+++ b/spec/bin/configure_spec.rb
@@ -139,7 +139,6 @@ RSpec.describe ConfigureCLI do
     let(:tag) { Faker::Lorem.word }
     let(:identifier) { SecureRandom.urlsafe_base64 }
     let(:publisher) { Faker::Internet.url }
-    let(:usage_policy) { Faker::Internet.url }
     let(:lang) { 'en' }
     let!(:keypair) { create(:keypair) }
 
@@ -157,7 +156,6 @@ RSpec.describe ConfigureCLI do
               '--identifier', identifier,
               '--tag', tag,
               '--publisher', publisher,
-              '--usage-policy', usage_policy,
               '--lang', lang]
 
       args += ['--hash', hash] if hash
@@ -184,26 +182,11 @@ RSpec.describe ConfigureCLI do
 
       it 'updates the PublicationInfo' do
         pi = instance.publication_info
-        up = pi.usage_policies.first
 
         run
 
         expect { pi.reload }.to change { pi.values }
           .to include(publisher: publisher)
-
-        expect { up.reload }.to change { up.values }
-          .to include(uri: usage_policy)
-      end
-
-      context 'when the PublicationInfo has two usage_policies' do
-        let!(:other_usage_policy) do
-          create(:mdrpi_usage_policy,
-                 publication_info: instance.publication_info)
-        end
-
-        it 'raises an exception' do
-          expect { run }.to raise_error(/multiple usage policies/)
-        end
       end
     end
 
@@ -218,15 +201,11 @@ RSpec.describe ConfigureCLI do
       it 'creates a valid PublicationInfo' do
         expect { run }.to change(MDRPI::PublicationInfo, :count)
           .by(1)
-          .and change(MDRPI::UsagePolicy, :count).by(1)
 
         md_instance = MetadataInstance.last
 
         expect(md_instance.publication_info)
           .to have_attributes(publisher: publisher)
-
-        expect(md_instance.publication_info.usage_policies.first)
-          .to have_attributes(uri: usage_policy)
       end
     end
 


### PR DESCRIPTION
This is inline with current changes to AAF metadata where we no longer want the PublicationInfo/UsagePolicy element to be published.

Requires merge of https://github.com/ausaccessfed/aaf-ansible/pull/714 in the same Ansible run.