### PR TITLE
Sirtifi contacts cascade delete

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -131,7 +131,7 @@ GEM
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
       ruby_dep (~> 1.2)
-    loofah (2.2.2)
+    loofah (2.2.3)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
     lumberjack (1.0.13)
@@ -167,7 +167,7 @@ GEM
     public_suffix (3.0.3)
     puma (3.12.0)
     raabro (1.1.6)
-    rack (2.0.5)
+    rack (2.0.6)
     rack-protection (2.0.4)
       rack
     rack-test (0.6.3)

--- a/app/models/entity_descriptor.rb
+++ b/app/models/entity_descriptor.rb
@@ -21,6 +21,7 @@ class EntityDescriptor < Sequel::Model
   plugin :touch
   plugin :association_dependencies, additional_metadata_locations: :destroy,
                                     contact_people: :destroy,
+                                    sirtfi_contact_people: :destroy,
                                     role_descriptors: :destroy,
                                     idp_sso_descriptors: :destroy,
                                     sp_sso_descriptors: :destroy,

--- a/config/database.yml
+++ b/config/database.yml
@@ -7,6 +7,7 @@ default: &default
   timeout: 5000
   encoding: utf8
   collation: utf8_bin
+  sql_mode: TRADITIONAL
 
 development:
   <<: *default

--- a/readme.md
+++ b/readme.md
@@ -30,9 +30,4 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ```
 
-*Current Release*: pre release, under development
-
 AAF service responsible for SAML data storage, metadata generation and inter-federation metadata processing.
-
-TODO: Write this document.
-

--- a/spec/factories/entity_descriptors.rb
+++ b/spec/factories/entity_descriptors.rb
@@ -58,5 +58,11 @@ FactoryBot.define do
         )
       end
     end
+
+    trait :with_sirtfi_contact do
+      after :create do |ed|
+        ed.add_sirtfi_contact_person create :sirtfi_contact_person, entity_descriptor: ed
+      end
+    end
   end
 end

--- a/spec/factories/entity_descriptors.rb
+++ b/spec/factories/entity_descriptors.rb
@@ -61,7 +61,8 @@ FactoryBot.define do
 
     trait :with_sirtfi_contact do
       after :create do |ed|
-        ed.add_sirtfi_contact_person create :sirtfi_contact_person, entity_descriptor: ed
+        ed.add_sirtfi_contact_person create :sirtfi_contact_person,
+                                            entity_descriptor: ed
       end
     end
   end

--- a/spec/models/entity_descriptor_spec.rb
+++ b/spec/models/entity_descriptor_spec.rb
@@ -19,6 +19,7 @@ describe EntityDescriptor do
   context 'optional attributes' do
     it { is_expected.to have_many_to_one :organization }
     it { is_expected.to have_one_to_many :contact_people }
+    it { is_expected.to have_one_to_many :sirtfi_contact_people }
     it { is_expected.to have_one_to_many :additional_metadata_locations }
     it { is_expected.to have_column :extensions, type: :text }
 
@@ -40,6 +41,11 @@ describe EntityDescriptor do
 
       it 'is valid without contacts' do
         expect(subject.contact_people).not_to be_present
+        expect(subject).to be_valid
+      end
+
+      it 'is valid without srtifi contacts' do
+        expect(subject.sirtfi_contact_people).not_to be_present
         expect(subject).to be_valid
       end
 
@@ -226,7 +232,7 @@ describe EntityDescriptor do
 
   describe '#destroy' do
     subject do
-      create :entity_descriptor, :with_technical_contact,
+      create :entity_descriptor, :with_technical_contact, :with_sirtfi_contact,
              :with_publication_info, :with_entity_attribute,
              :with_refeds_rs_entity_category,
              :with_idp, :with_sp, :with_aa


### PR DESCRIPTION
Previously deleting an ED with a sirtfi contact would result in a
failure such as:

```
/opt/saml/repository/vendor/bundle/ruby/2.4.0/gems/mysql2-0.5.1/lib/mysql2/client.rb:131:in `_query': 
Mysql2::Error: Cannot delete or update a parent row: a foreign key constraint fails 
(`saml_production`.`sirtfi_contact_people`, CONSTRAINT `sirtfi_ed_cp_fkey` FOREIGN KEY 
(`entity_descriptor_id`) REFERENCES `entity_descriptors` (`id`)) 
(Sequel::ForeignKeyConstraintViolation)
```

This PR additionally:

* Solves a problem running SAML service on MySQL 5.7.5+
* Addresses known security vulnerabilities in dependencies.