### PR TITLE
Increase localizedName to 2048 char

### DIFF
--- a/db/migrate/20190225092700_alter_localized_names.rb
+++ b/db/migrate/20190225092700_alter_localized_names.rb
@@ -1,0 +1,8 @@
+Sequel.migration do
+  change do
+    alter_table :localized_names do
+       set_column_type :value, 'varchar(2048)'
+    end
+  end
+end
+                        

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -93,7 +93,7 @@ Sequel.migration do
     
     create_table(:localized_names) do
       primary_key :id, :type=>"int(11)"
-      column :value, "varchar(255)", :null=>false
+      column :value, "varchar(2048)", :null=>false
       column :lang, "varchar(255)", :null=>false
       column :created_at, "datetime"
       column :updated_at, "datetime"
@@ -891,5 +891,6 @@ self << "INSERT INTO `schema_migrations` (`filename`) VALUES ('20170619194544_cr
 self << "INSERT INTO `schema_migrations` (`filename`) VALUES ('20170802213241_make_key_type_id_nullable.rb')"
 self << "INSERT INTO `schema_migrations` (`filename`) VALUES ('20170802230844_allow_larger_rank_values.rb')"
 self << "INSERT INTO `schema_migrations` (`filename`) VALUES ('20170803002700_create_sirtfi_contact_people.rb')"
+self << "INSERT INTO `schema_migrations` (`filename`) VALUES ('20190225092700_alter_localized_names.rb')"
                 end
               end


### PR DESCRIPTION
Due to a failure when a subscriber entered an extensive description for
a service this field was determined to be overly restrictive.

We'll see how 2048 goes in production, there is scope here to double
again to 4096 if we deem necessary.

Fixes #195.