### PR TITLE
Bugfix - KeyInfo truncations

### DIFF
--- a/db/migrate/20190225092700_alter_localized_names.rb
+++ b/db/migrate/20190225092700_alter_localized_names.rb
@@ -1,7 +1,13 @@
 Sequel.migration do
-  change do
+  up do
     alter_table :localized_names do
        set_column_type :value, 'varchar(2048)'
+    end
+  end
+
+  down do
+    alter_table :localized_names do
+       set_column_type :value, 'varchar(255)'
     end
   end
 end

--- a/db/migrate/20190320095000_alter_key_subject_issuer.rb
+++ b/db/migrate/20190320095000_alter_key_subject_issuer.rb
@@ -1,0 +1,16 @@
+Sequel.migration do
+  up do
+    alter_table :key_infos do
+       set_column_type :subject, 'varchar(2048)'
+       set_column_type :issuer, 'varchar(2048)'
+    end
+  end
+
+  down do
+    alter_table :key_infos do
+       set_column_type :subject, 'varchar(255)'
+       set_column_type :issuer, 'varchar(255)'
+    end
+  end
+end
+                        

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -662,8 +662,8 @@ Sequel.migration do
     create_table(:key_infos) do
       primary_key :id, :type=>"int(11)"
       column :data, "text", :null=>false
-      column :subject, "varchar(255)"
-      column :issuer, "varchar(255)"
+      column :subject, "varchar(2048)"
+      column :issuer, "varchar(2048)"
       column :key_name, "varchar(255)"
       column :expiry, "datetime"
       column :created_at, "datetime"
@@ -892,5 +892,6 @@ self << "INSERT INTO `schema_migrations` (`filename`) VALUES ('20170802213241_ma
 self << "INSERT INTO `schema_migrations` (`filename`) VALUES ('20170802230844_allow_larger_rank_values.rb')"
 self << "INSERT INTO `schema_migrations` (`filename`) VALUES ('20170803002700_create_sirtfi_contact_people.rb')"
 self << "INSERT INTO `schema_migrations` (`filename`) VALUES ('20190225092700_alter_localized_names.rb')"
+self << "INSERT INTO `schema_migrations` (`filename`) VALUES ('20190320095000_alter_key_subject_issuer.rb')"
                 end
               end


### PR DESCRIPTION
During production operation of SAML Service we had a data migration failure causing total transaction rollback when importing from FR.

Investigation showed that CSIRO had provided a KeyInfo Subject line that far exceeded our previous 255 limit.

As this is essentially a game of 'whack-a-mole' with regards to what is the correct column width to support here I have gone for the win and taken this right out to 2048, which at the length of a short novel and far greater than that allowed in even a modern tweet, should see us avoid this issue in the future.