### PR TITLE
Auto-Tag GEANT DataProtection Code of Conduct

### DIFF
--- a/app/jobs/concerns/set_saml_type_from_xml.rb
+++ b/app/jobs/concerns/set_saml_type_from_xml.rb
@@ -57,13 +57,14 @@ module SetSAMLTypeFromXML
   def desired_entity_category_tags(ed_node)
     tags = []
     tags << Tag::RESEARCH_SCHOLARSHIP if research_scholarship_entity?(ed_node)
+    tags << Tag::DP_COCO if dp_coco_entity?(ed_node)
     tags << Tag::SIRTFI if sirtfi_entity?(ed_node)
     tags
   end
 
   def all_entity_tags
     [Tag::IDP, Tag::AA, Tag::STANDALONE_AA, Tag::SP,
-     Tag::RESEARCH_SCHOLARSHIP, Tag::SIRTFI]
+     Tag::RESEARCH_SCHOLARSHIP, Tag::DP_COCO, Tag::SIRTFI]
   end
 
   def entity_has_idp_role?(ed_node)
@@ -103,6 +104,29 @@ module SetSAMLTypeFromXML
     matches_entity_attribute_value?(
       ed_node, 'http://macedir.org/entity-category-support',
       'http://refeds.org/category/research-and-scholarship'
+    )
+  end
+
+  def dp_coco_entity?(ed_node)
+    sp_has_dp_coco?(ed_node) ||
+      idp_supports_dp_coco?(ed_node)
+  end
+
+  def sp_has_dp_coco?(ed_node)
+    return false unless entity_has_sp_role?(ed_node)
+
+    matches_entity_attribute_value?(
+      ed_node, 'http://macedir.org/entity-category',
+      'http://www.geant.net/uri/dataprotection-code-of-conduct/v1'
+    )
+  end
+
+  def idp_supports_dp_coco?(ed_node)
+    return false unless entity_has_idp_role?(ed_node)
+
+    matches_entity_attribute_value?(
+      ed_node, 'http://macedir.org/entity-category-support',
+      'http://www.geant.net/uri/dataprotection-code-of-conduct/v1'
     )
   end
 

--- a/app/jobs/concerns/set_saml_type_from_xml.rb
+++ b/app/jobs/concerns/set_saml_type_from_xml.rb
@@ -11,6 +11,8 @@ module SetSAMLTypeFromXML
   SP_SSO_DESCRIPTOR_XPATH = xpath_for_metadata_element('SPSSODescriptor')
   ATTRIBUTE_AUTHORITY_DESCRIPTOR_XPATH =
     xpath_for_metadata_element('AttributeAuthorityDescriptor')
+  RESEEARCH_AND_SCHOLARSHIP_CATEGORY = 'http://refeds.org/category/research-and-scholarship'
+  DP_COCO_CATEGORY = 'http://www.geant.net/uri/dataprotection-code-of-conduct/v1'
 
   def self.xpath_for_entity_attribute_values(name)
     './/*[local-name() = "EntityAttributes" ' \
@@ -85,48 +87,28 @@ module SetSAMLTypeFromXML
   end
 
   def research_scholarship_entity?(ed_node)
-    sp_has_research_scholarship_category?(ed_node) ||
-      idp_supports_research_scholarship_category?(ed_node)
-  end
-
-  def sp_has_research_scholarship_category?(ed_node)
-    return false unless entity_has_sp_role?(ed_node)
-
-    matches_entity_attribute_value?(
-      ed_node, 'http://macedir.org/entity-category',
-      'http://refeds.org/category/research-and-scholarship'
-    )
-  end
-
-  def idp_supports_research_scholarship_category?(ed_node)
-    return false unless entity_has_idp_role?(ed_node)
-
-    matches_entity_attribute_value?(
-      ed_node, 'http://macedir.org/entity-category-support',
-      'http://refeds.org/category/research-and-scholarship'
-    )
+    sp_has_category?(ed_node, RESEEARCH_AND_SCHOLARSHIP_CATEGORY) ||
+      idp_supports_category?(ed_node, RESEEARCH_AND_SCHOLARSHIP_CATEGORY)
   end
 
   def dp_coco_entity?(ed_node)
-    sp_has_dp_coco?(ed_node) ||
-      idp_supports_dp_coco?(ed_node)
+    sp_has_category?(ed_node, DP_COCO_CATEGORY) ||
+      idp_supports_category?(ed_node, DP_COCO_CATEGORY)
   end
 
-  def sp_has_dp_coco?(ed_node)
+  def sp_has_category?(ed_node, category)
     return false unless entity_has_sp_role?(ed_node)
 
     matches_entity_attribute_value?(
-      ed_node, 'http://macedir.org/entity-category',
-      'http://www.geant.net/uri/dataprotection-code-of-conduct/v1'
+      ed_node, 'http://macedir.org/entity-category', category
     )
   end
 
-  def idp_supports_dp_coco?(ed_node)
+  def idp_supports_category?(ed_node, category)
     return false unless entity_has_idp_role?(ed_node)
 
     matches_entity_attribute_value?(
-      ed_node, 'http://macedir.org/entity-category-support',
-      'http://www.geant.net/uri/dataprotection-code-of-conduct/v1'
+      ed_node, 'http://macedir.org/entity-category-support', category
     )
   end
 

--- a/app/jobs/concerns/set_saml_type_from_xml.rb
+++ b/app/jobs/concerns/set_saml_type_from_xml.rb
@@ -11,7 +11,7 @@ module SetSAMLTypeFromXML
   SP_SSO_DESCRIPTOR_XPATH = xpath_for_metadata_element('SPSSODescriptor')
   ATTRIBUTE_AUTHORITY_DESCRIPTOR_XPATH =
     xpath_for_metadata_element('AttributeAuthorityDescriptor')
-  RESEEARCH_AND_SCHOLARSHIP_CATEGORY = 'http://refeds.org/category/research-and-scholarship'
+  RESEARCH_AND_SCHOLARSHIP_CATEGORY = 'http://refeds.org/category/research-and-scholarship'
   DP_COCO_CATEGORY = 'http://www.geant.net/uri/dataprotection-code-of-conduct/v1'
 
   def self.xpath_for_entity_attribute_values(name)
@@ -87,8 +87,8 @@ module SetSAMLTypeFromXML
   end
 
   def research_scholarship_entity?(ed_node)
-    sp_has_category?(ed_node, RESEEARCH_AND_SCHOLARSHIP_CATEGORY) ||
-      idp_supports_category?(ed_node, RESEEARCH_AND_SCHOLARSHIP_CATEGORY)
+    sp_has_category?(ed_node, RESEARCH_AND_SCHOLARSHIP_CATEGORY) ||
+      idp_supports_category?(ed_node, RESEARCH_AND_SCHOLARSHIP_CATEGORY)
   end
 
   def dp_coco_entity?(ed_node)

--- a/app/jobs/concerns/set_saml_type_from_xml.rb
+++ b/app/jobs/concerns/set_saml_type_from_xml.rb
@@ -13,6 +13,8 @@ module SetSAMLTypeFromXML
     xpath_for_metadata_element('AttributeAuthorityDescriptor')
   RESEARCH_AND_SCHOLARSHIP_CATEGORY = 'http://refeds.org/category/research-and-scholarship'
   DP_COCO_CATEGORY = 'http://www.geant.net/uri/dataprotection-code-of-conduct/v1'
+  ENTITY_CATEGORY_ATTR = 'http://macedir.org/entity-category'
+  ENTITY_CATEGORY_SUPPORT_ATTR = 'http://macedir.org/entity-category-support'
 
   def self.xpath_for_entity_attribute_values(name)
     './/*[local-name() = "EntityAttributes" ' \
@@ -100,7 +102,7 @@ module SetSAMLTypeFromXML
     return false unless entity_has_sp_role?(ed_node)
 
     matches_entity_attribute_value?(
-      ed_node, 'http://macedir.org/entity-category', category
+      ed_node, ENTITY_CATEGORY_ATTR, category
     )
   end
 
@@ -108,7 +110,7 @@ module SetSAMLTypeFromXML
     return false unless entity_has_idp_role?(ed_node)
 
     matches_entity_attribute_value?(
-      ed_node, 'http://macedir.org/entity-category-support', category
+      ed_node, ENTITY_CATEGORY_SUPPORT_ATTR, category
     )
   end
 

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -22,6 +22,7 @@ class Tag < Sequel::Model
   STANDALONE_AA = 'standalone-aa'
   SP = 'sp'
   RESEARCH_SCHOLARSHIP = 'research-and-scholarship'
+  DP_COCO = 'dp-coco'
   SIRTFI = 'sirtfi'
   BLACKLIST = 'blacklist'
 end

--- a/spec/jobs/concerns/set_saml_type_from_xml_spec.rb
+++ b/spec/jobs/concerns/set_saml_type_from_xml_spec.rb
@@ -39,6 +39,20 @@ RSpec.describe SetSAMLTypeFromXML do
     }
   end
 
+  let(:supports_dp_coco) do
+    {
+      'http://macedir.org/entity-category-support' =>
+      [attribute_value('http://www.geant.net/uri/dataprotection-code-of-conduct/v1')]
+    }
+  end
+
+  let(:conforms_to_dp_coco) do
+    {
+      'http://macedir.org/entity-category' =>
+      [attribute_value('http://www.geant.net/uri/dataprotection-code-of-conduct/v1')]
+    }
+  end
+
   let(:xpath_results) do
     {
       'IDPSSODescriptor' => idp_sso_descriptor,
@@ -101,6 +115,7 @@ RSpec.describe SetSAMLTypeFromXML do
         expect(known_entity).to have_received(:untag_as).with('sirtfi')
         expect(known_entity).to have_received(:untag_as)
           .with('research-and-scholarship')
+        expect(known_entity).to have_received(:untag_as).with('dp-coco')
       end
     end
 
@@ -138,6 +153,15 @@ RSpec.describe SetSAMLTypeFromXML do
             .with('research-and-scholarship')
         end
       end
+
+      context 'when DPCoCo is supported' do
+        let(:entity_attributes) { supports_dp_coco }
+
+        it 'adds the tag' do
+          expect(known_entity).to have_received(:tag_as)
+            .with('dp-coco')
+        end
+      end
     end
 
     context 'with an SPSSODescriptor' do
@@ -172,6 +196,15 @@ RSpec.describe SetSAMLTypeFromXML do
         it 'adds the tag' do
           expect(known_entity).to have_received(:tag_as)
             .with('research-and-scholarship')
+        end
+      end
+
+      context 'when conforming to DP-Coco' do
+        let(:entity_attributes) { conforms_to_dp_coco }
+
+        it 'adds the tag' do
+          expect(known_entity).to have_received(:tag_as)
+            .with('dp-coco')
         end
       end
     end


### PR DESCRIPTION

Hi @bradleybeddoes ,

When deploying our SAML Service instance and looking around the options, I noticed it the code you pointed me to does auto-tag R&S entities, but not the GEANT Data Protection Code of Conduct [1] - which is declared in a similar way, just with a different category name.

I have added the tag definition and auto-tagging code.

And tests.  And refactored the code to get within the lines of code limits enforced by Rubocop - that was actually good to avoid duplicating the entity category code.

Would you be in principle happy to merge this?

And if so, does this look to you all good, or are there any changes you'd want me to do?

Cheers,
Vlad

Refs:
[1] https://wiki.refeds.org/display/CODE/Data+Protection+Code+of+Conduct+Home