### PR TITLE
FRsync: Fix: also remove KnownEntity when removing ED

### DIFF
--- a/app/jobs/concerns/etl/entity_descriptors.rb
+++ b/app/jobs/concerns/etl/entity_descriptors.rb
@@ -92,7 +92,9 @@ module ETL
       return if ed.blank?
 
       Rails.logger.info "Destroying FR entity #{ed_data[:entity_id]}"
+      ke = ed.known_entity
       ed.destroy
+      ke.destroy
     end
   end
 end


### PR DESCRIPTION
Hi @bradleybeddoes ,

A minor fix: when experimenting, I found that when I mark an entity Inactive in FR, the EntityDescriptor gets removed, but the KnownEntity object is left behind...

Fix tested, rspec tests passed...

Cheers,
Vlad