### PR TITLE
sync_to_git.rb: add config file

### DIFF
--- a/bin/sync_to_git_repository.rb
+++ b/bin/sync_to_git_repository.rb
@@ -107,8 +107,8 @@ class SyncToGitRepository
   end
 
   def commit(tree, message)
-    author = { name: 'SAML Service', time: Time.now.getlocal,
-               email: 'noreply@aaf.edu.au' }
+    author = { name: @config['git_author_name'], time: Time.now.getlocal,
+               email: @config['git_author_email'] }
 
     Rugged::Commit.create(@repository,
                           tree: tree, message: message,

--- a/bin/sync_to_git_repository.rb
+++ b/bin/sync_to_git_repository.rb
@@ -9,14 +9,16 @@ class SyncToGitRepository
   include Metadata::SAMLNamespaces
 
   def initialize(args)
-    if args.length != 1
-      warn("usage: #{$PROGRAM_NAME} /path/to/config/file")
+    if args.length != 3
+      warn("usage: #{$PROGRAM_NAME} /path/to/config/file" \
+                   'md_instance_identifier /path/to/git/repository')
       exit 1
     end
 
-    @config = YAML.load_file(args[0])
-    @md_instance = MetadataInstance[identifier: @config['instance_identifier']]
-    @repository = Rugged::Repository.new(@config['repository_path'])
+    config_file_path, instance_identifier, repository_path = args
+    @config = YAML.load_file(config_file_path)
+    @md_instance = MetadataInstance[identifier: instance_identifier]
+    @repository = Rugged::Repository.new(repository_path)
     @committed = false
   end
 

--- a/bin/sync_to_git_repository.rb
+++ b/bin/sync_to_git_repository.rb
@@ -9,15 +9,14 @@ class SyncToGitRepository
   include Metadata::SAMLNamespaces
 
   def initialize(args)
-    if args.length != 2
-      warn("usage: #{$PROGRAM_NAME} md_instance_identifier " \
-                   '/path/to/git/repository')
+    if args.length != 1
+      warn("usage: #{$PROGRAM_NAME} /path/to/config/file")
       exit 1
     end
 
-    instance_identifier, repository_path = args
-    @md_instance = MetadataInstance[identifier: instance_identifier]
-    @repository = Rugged::Repository.new(repository_path)
+    @config = YAML.load_file(args[0])
+    @md_instance = MetadataInstance[identifier: @config['instance_identifier']]
+    @repository = Rugged::Repository.new(@config['repository_path'])
     @committed = false
   end
 

--- a/bin/sync_to_git_repository.rb
+++ b/bin/sync_to_git_repository.rb
@@ -78,7 +78,8 @@ class SyncToGitRepository
     if ke.entity_descriptor.try(:functioning?)
       renderer.entity_descriptor(ke.entity_descriptor, NAMESPACES)
     elsif ke.raw_entity_descriptor.try(:functioning?)
-      renderer.raw_entity_descriptor(ke.raw_entity_descriptor, NAMESPACES, true)
+      renderer.raw_entity_descriptor(ke.raw_entity_descriptor, NAMESPACES,
+                                     @config['raw_entity_descriptor_root_node'])
     end
 
     doc = renderer.builder.doc

--- a/bin/sync_to_git_repository.rb
+++ b/bin/sync_to_git_repository.rb
@@ -44,20 +44,19 @@ class SyncToGitRepository
     end
   end
 
-  def find_branch
-    @repository.branches.find do |b|
+  # rubocop:disable Metrics/AbcSize
+  def push
+    branch = @repository.branches.find do |b|
       b.canonical_name == @repository.head.canonical_name
     end
-  end
 
-  def push
-    branch = find_branch
     remote = @repository.config["branch.#{branch.name}.remote"]
     merge = @repository.config["branch.#{branch.name}.merge"]
 
     @repository.push(remote, "#{branch.canonical_name}:#{merge}",
                      credentials: credential)
   end
+  # rubocop:enable Metrics/AbcSize
 
   def sync(ke)
     return if ke.entity_id.nil?

--- a/config/sync_to_git_repository.yml.dist
+++ b/config/sync_to_git_repository.yml.dist
@@ -1,0 +1,4 @@
+---
+instance_identifier: aaf
+repository_path: /path/to/git/repository
+...

--- a/config/sync_to_git_repository.yml.dist
+++ b/config/sync_to_git_repository.yml.dist
@@ -1,6 +1,4 @@
 ---
-instance_identifier: aaf
-repository_path: /path/to/git/repository
 git_author_name: SAML Service
 git_author_email: noreply@aaf.edu.au
 git_auth:

--- a/config/sync_to_git_repository.yml.dist
+++ b/config/sync_to_git_repository.yml.dist
@@ -1,4 +1,6 @@
 ---
 instance_identifier: aaf
 repository_path: /path/to/git/repository
+git_author_name: SAML Service
+git_author_email: noreply@aaf.edu.au
 ...

--- a/config/sync_to_git_repository.yml.dist
+++ b/config/sync_to_git_repository.yml.dist
@@ -3,4 +3,6 @@ instance_identifier: aaf
 repository_path: /path/to/git/repository
 git_author_name: SAML Service
 git_author_email: noreply@aaf.edu.au
+# whether to construct a new root node
+raw_entity_descriptor_root_node: True
 ...

--- a/config/sync_to_git_repository.yml.dist
+++ b/config/sync_to_git_repository.yml.dist
@@ -3,6 +3,17 @@ instance_identifier: aaf
 repository_path: /path/to/git/repository
 git_author_name: SAML Service
 git_author_email: noreply@aaf.edu.au
+git_auth:
+  # Supported auth types and their parameters:
+  #type: sshkey
+  #username: git
+  #publickey: "/home/saml/.ssh/id_rsa.pub"
+  #privatekey: "/home/saml/.ssh/id_rsa"
+  #passphrase: ""
+  #
+  #type: userpassword
+  #username: git
+  #password: "secretuserpassword"
 # whether to construct a new root node
 raw_entity_descriptor_root_node: True
 ...

--- a/spec/bin/sync_to_git_repository_spec.rb
+++ b/spec/bin/sync_to_git_repository_spec.rb
@@ -120,7 +120,8 @@ RSpec.describe SyncToGitRepository do
         run
 
         expect(repo).to have_received(:push)
-          .with(remote_name, "#{canonical_branch_name}:#{remote_branch}")
+          .with(remote_name, "#{canonical_branch_name}:#{remote_branch}",
+                any_args)
       end
     end
 
@@ -155,7 +156,8 @@ RSpec.describe SyncToGitRepository do
         run
 
         expect(repo).to have_received(:push)
-          .with(remote_name, "#{canonical_branch_name}:#{remote_branch}")
+          .with(remote_name, "#{canonical_branch_name}:#{remote_branch}",
+                any_args)
       end
     end
 

--- a/spec/bin/sync_to_git_repository_spec.rb
+++ b/spec/bin/sync_to_git_repository_spec.rb
@@ -63,7 +63,8 @@ RSpec.describe SyncToGitRepository do
         'instance_identifier' => md_instance.identifier,
         'repository_path' => path,
         'git_author_name' => 'SAML Service',
-        'git_author_email' => 'noreply@aaf.edu.au'
+        'git_author_email' => 'noreply@aaf.edu.au',
+        'raw_entity_descriptor_root_node' => true
       }
     end
 

--- a/spec/bin/sync_to_git_repository_spec.rb
+++ b/spec/bin/sync_to_git_repository_spec.rb
@@ -28,6 +28,8 @@ RSpec.describe SyncToGitRepository do
                                    .and_return(remote_name)
       allow(config).to receive(:[]).with("branch.#{branch_name}.merge")
                                    .and_return(remote_branch)
+      allow(YAML).to receive(:load_file).with(sync_config_path)
+                                        .and_return(sync_config)
     end
 
     let(:written_blobs) { {} }
@@ -54,6 +56,14 @@ RSpec.describe SyncToGitRepository do
     let(:head_tree) { double(Rugged::Tree) }
     let(:new_tree) { double(Rugged::Tree) }
     let(:config) { double(Rugged::Config) }
+    let(:sync_config_path) { Faker::Lorem.words.unshift('').join('/') }
+
+    let(:sync_config) do
+      {
+        'instance_identifier' => md_instance.identifier,
+        'repository_path' => path
+      }
+    end
 
     let(:head) do
       double(Rugged::Reference, target: head_commit,
@@ -71,7 +81,7 @@ RSpec.describe SyncToGitRepository do
              config: config, branches: [branch])
     end
 
-    subject { described_class.new([md_instance.identifier, path]) }
+    subject { described_class.new([sync_config_path]) }
 
     def run
       subject.perform

--- a/spec/bin/sync_to_git_repository_spec.rb
+++ b/spec/bin/sync_to_git_repository_spec.rb
@@ -61,7 +61,9 @@ RSpec.describe SyncToGitRepository do
     let(:sync_config) do
       {
         'instance_identifier' => md_instance.identifier,
-        'repository_path' => path
+        'repository_path' => path,
+        'git_author_name' => 'SAML Service',
+        'git_author_email' => 'noreply@aaf.edu.au'
       }
     end
 

--- a/spec/bin/sync_to_git_repository_spec.rb
+++ b/spec/bin/sync_to_git_repository_spec.rb
@@ -60,8 +60,6 @@ RSpec.describe SyncToGitRepository do
 
     let(:sync_config) do
       {
-        'instance_identifier' => md_instance.identifier,
-        'repository_path' => path,
         'git_author_name' => 'SAML Service',
         'git_author_email' => 'noreply@aaf.edu.au',
         'raw_entity_descriptor_root_node' => true
@@ -84,7 +82,9 @@ RSpec.describe SyncToGitRepository do
              config: config, branches: [branch])
     end
 
-    subject { described_class.new([sync_config_path]) }
+    subject do
+      described_class.new([sync_config_path, md_instance.identifier, path])
+    end
 
     def run
       subject.perform

--- a/spec/factories/raw_entity_descriptors.rb
+++ b/spec/factories/raw_entity_descriptors.rb
@@ -12,7 +12,7 @@ FactoryBot.define do
     association :known_entity
 
     xml do
-      <<-ENTITY.strip_heredoc
+      <<-ENTITY.strip_heredoc.strip
         <EntityDescriptor xmlns="urn:oasis:names:tc:SAML:2.0:metadata"
           xmlns:mdui="urn:oasis:names:tc:SAML:metadata:ui"
           entityID="#{entity_id_uri}">
@@ -58,7 +58,7 @@ FactoryBot.define do
     factory :raw_entity_descriptor_idp do
       idp true
       xml do
-        <<-ENTITY.strip_heredoc
+        <<-ENTITY.strip_heredoc.strip
           <EntityDescriptor xmlns="urn:oasis:names:tc:SAML:2.0:metadata"
             xmlns:mdui="urn:oasis:names:tc:SAML:metadata:ui"
             entityID="#{entity_id_uri}">
@@ -102,7 +102,7 @@ FactoryBot.define do
     factory :raw_entity_descriptor_sp do
       sp true
       xml do
-        <<-ENTITY.strip_heredoc
+        <<-ENTITY.strip_heredoc.strip
           <EntityDescriptor xmlns="urn:oasis:names:tc:SAML:2.0:metadata"
             xmlns:idpdisc=
               "urn:oasis:names:tc:SAML:profiles:SSO:idp-discovery-protocol"
@@ -156,7 +156,7 @@ FactoryBot.define do
       association :known_entity
 
       xml do
-        <<-ENTITY.strip_heredoc
+        <<-ENTITY.strip_heredoc.strip
           <EntityDescriptor xmlns="urn:oasis:names:tc:SAML:2.0:metadata"
             xmlns:mdui="urn:oasis:names:tc:SAML:metadata:ui"
             entityID="#{entity_id_uri}">
@@ -211,7 +211,7 @@ FactoryBot.define do
       association :known_entity
 
       xml do
-        <<-ENTITY.strip_heredoc
+        <<-ENTITY.strip_heredoc.strip
           <xyz:EntityDescriptor xmlns:xyz="urn:oasis:names:tc:SAML:2.0:metadata"
             xmlns:mdui="urn:oasis:names:tc:SAML:metadata:ui"
             entityID="#{entity_id_uri}">


### PR DESCRIPTION
Hi @bradleybeddoes ,

As discussed in #204, I have added a config file for `bin/sync_to_git_repository.rb`

I first tried to put everything into the config (including the md_instance_identiifer and path to git repo), but then realised it would not support tracking multiple metadata instances (in separate git repos) - which we do.

So in the end, the config file is added to the start of the command line, but the md_instance_id and git repo path still stay on the commmand line.

I have tested this throughly - and it is now in use in our Tuakiri deployment.

All `rspec` tests pass.

Looks good to you to merge?

Cheers,
Vlad

PS: Full disclosure: rubocop is not happy about the length of the file (102/100 lines), but I think moving stuff into a separate file would hurt more then help.  I moved the code for finding the branch into a separate function, because the ABCSize metric for `push` was too high.  If I move it back in, LOC is within limits, but ABCSize for `push` is 15.3/15.  Could not find a suitable way of negotiating a clean pass with rubocop....
