### PR TITLE
Locked scopes

### DIFF
--- a/app/jobs/concerns/etl/role_descriptors.rb
+++ b/app/jobs/concerns/etl/role_descriptors.rb
@@ -10,7 +10,9 @@ module ETL
     end
 
     def scopes(rd, scope_data)
-      rd.scopes.each(&:destroy)
+      # Any scopes which we've added locally i.e. no knowledge
+      # from FR are not removed
+      rd.scopes.select(&:unlocked?).each(&:destroy)
       rd.add_scope(SHIBMD::Scope.new(value: scope_data,
                                      regexp: regexp_scope?(scope_data)))
     end

--- a/app/models/shibmd/scope.rb
+++ b/app/models/shibmd/scope.rb
@@ -4,6 +4,14 @@ module SHIBMD
   class Scope < Sequel::Model
     many_to_one :role_descriptor, class: 'RoleDescriptor'
 
+    # Locked scopes are not to be removed during ETL processes
+    # as they are entered directly to SAML service in order
+    # to work around an FR limitation that only supports
+    # a single scope per RD.
+    def unlocked?
+      !locked
+    end
+
     def validate
       super
 

--- a/db/migrate/20191203011131_add_fixed_boolean_to_shibmd_scope.rb
+++ b/db/migrate/20191203011131_add_fixed_boolean_to_shibmd_scope.rb
@@ -1,0 +1,7 @@
+Sequel.migration do
+  change do
+    alter_table :scopes do
+      add_column :locked, :boolean, default: false, null: false
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -545,6 +545,7 @@ Sequel.migration do
       column :regexp, "tinyint(1)", :default=>false, :null=>false
       column :created_at, "datetime", :null=>false
       column :updated_at, "datetime", :null=>false
+      column :locked, "tinyint(1)", :default=>false, :null=>false
       
       index [:role_descriptor_id], :name=>:scope_rd_fkey
     end
@@ -893,5 +894,6 @@ self << "INSERT INTO `schema_migrations` (`filename`) VALUES ('20170802230844_al
 self << "INSERT INTO `schema_migrations` (`filename`) VALUES ('20170803002700_create_sirtfi_contact_people.rb')"
 self << "INSERT INTO `schema_migrations` (`filename`) VALUES ('20190225092700_alter_localized_names.rb')"
 self << "INSERT INTO `schema_migrations` (`filename`) VALUES ('20190320095000_alter_key_subject_issuer.rb')"
+self << "INSERT INTO `schema_migrations` (`filename`) VALUES ('20191203011131_add_fixed_boolean_to_shibmd_scope.rb')"
                 end
               end

--- a/spec/factories/shibmd_scopes.rb
+++ b/spec/factories/shibmd_scopes.rb
@@ -3,7 +3,8 @@
 FactoryBot.define do
   factory :shibmd_scope, class: 'SHIBMD::Scope' do
     association :role_descriptor, factory: :idp_sso_descriptor
-    value Faker::Internet.domain_name
+    value { Faker::Internet.domain_name }
     regexp false
+    locked false
   end
 end

--- a/spec/support/jobs/concerns/etl/identity_providers.rb
+++ b/spec/support/jobs/concerns/etl/identity_providers.rb
@@ -339,7 +339,7 @@ RSpec.shared_examples 'ETL::IdentityProviders' do
     end
   end
 
-  context 'updating an IDPSSODescriptor with locked scope', focus: true do
+  context 'updating an IDPSSODescriptor with locked scope' do
     let(:idp_count) { 1 }
     let(:contact_count) { 1 }
     let(:sirtfi_contact_count) { 1 }
@@ -356,11 +356,11 @@ RSpec.shared_examples 'ETL::IdentityProviders' do
       expect(subject.scopes.first.value).to eq(scope)
 
       locked_scope = create :shibmd_scope, role_descriptor: subject,
-        locked: true
+                                           locked: true
       expect(subject.scopes.size).to eq(2)
 
-      # Run update again so we can ensure our update subject retains the manually
-      # added but locked scope
+      # Run update again so we can ensure our update subject retains the
+      # manually added but locked scope
       run
       expect(subject.scopes.size).to eq(2)
       expect(subject.scopes.first.value).to eq(scope)


### PR DESCRIPTION
An AAF customer had a legitimate need to support multiple scopes within their metadata snippet. This was originally achieved with a regexp scope but the approach was rejected by international federations that filter metadata including JISC and Incommon.

This commit accepts a single value from FR for scope (which is all it can provide) and permits additional 'locked' scopes to be manually entered into the SAML service database if necessary to provide second, third etc scopes in metadata.


https://github.com/ausaccessfed/saml-service/compare/security/CVE-2019-15587...feature/locked-scopes