### PR TITLE
Upgrade Rubocop to 0.80.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -247,6 +247,7 @@ GEM
       redis (>= 3.3)
       resque (>= 1.26)
       rufus-scheduler (~> 3.2)
+    rexml (3.2.4)
     rspec (3.9.0)
       rspec-core (~> 3.9.0)
       rspec-expectations (~> 3.9.0)
@@ -270,11 +271,12 @@ GEM
     rspec-retry (0.6.2)
       rspec-core (> 3.3)
     rspec-support (3.9.2)
-    rubocop (0.79.0)
+    rubocop (0.80.0)
       jaro_winkler (~> 1.5.1)
       parallel (~> 1.10)
       parser (>= 2.7.0.1)
       rainbow (>= 2.2.2, < 4.0)
+      rexml
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 1.4.0, < 1.7)
     rubocop-faker (0.2.0)
@@ -389,4 +391,4 @@ DEPENDENCIES
   xmldsig
 
 BUNDLED WITH
-   1.16.4
+   1.17.2

--- a/bin/configure.rb
+++ b/bin/configure.rb
@@ -4,7 +4,7 @@
 require_relative '../config/environment'
 require 'thor'
 
-# rubocop:disable ClassLength
+# rubocop:disable Metrics/ClassLength
 class ConfigureCLI < Thor
   desc 'fr_source [options...]', 'Create or update a Federation Registry source'
   option :source_tag,
@@ -159,6 +159,6 @@ class ConfigureCLI < Thor
     pi.update(publisher: options[:publisher], metadata_instance_id: instance.id)
   end
 end
-# rubocop:enable ClassLength
+# rubocop:enable Metrics/ClassLength
 
 ConfigureCLI.start(ARGV) if $PROGRAM_NAME == __FILE__

--- a/config/application.rb
+++ b/config/application.rb
@@ -30,7 +30,7 @@ module Saml
     end
 
     config.cache_store = :redis_store, 'redis://localhost:6379/0/cache'
-    config.autoload_paths << Rails.root.join('app/jobs/concerns')
+    config.autoload_paths << Rails.root.join('app', 'jobs', 'concerns')
 
     config.sequel.logger = Logger.new($stderr) if ENV['AAF_DEBUG']
   end

--- a/lib/metadata/schema.rb
+++ b/lib/metadata/schema.rb
@@ -9,7 +9,7 @@ module Metadata
     private
 
     def file
-      Rails.root.join('schema/top.xsd')
+      Rails.root.join('schema', 'top.xsd')
     end
   end
 end

--- a/spec/bin/configure_spec.rb
+++ b/spec/bin/configure_spec.rb
@@ -230,7 +230,7 @@ RSpec.describe ConfigureCLI do
   describe '#raw_entity_source' do
     let(:rank) { Faker::Number.number(digits: 2).to_i }
     let(:url) { Faker::Internet.url }
-    let(:cert_path) { Rails.root.join('spec/tmp/res_cert.pem') }
+    let(:cert_path) { Rails.root.join('spec', 'tmp', 'res_cert.pem') }
     let(:rsa_key) { create(:rsa_key) }
     let(:x509_certificate) { create(:certificate, rsa_key: rsa_key) }
     let(:source_tag) { Faker::Lorem.words.join('-') }
@@ -255,7 +255,7 @@ RSpec.describe ConfigureCLI do
     end
 
     context 'when a source exists' do
-      let(:cert_path2) { Rails.root.join('spec/tmp/res_cert_new.pem') }
+      let(:cert_path2) { Rails.root.join('spec', 'tmp', 'res_cert_new.pem') }
       let(:rsa_key2) { create(:rsa_key) }
       let(:x509_certificate2) { create(:certificate, rsa_key: rsa_key) }
       let!(:source) do

--- a/spec/bin/sync_spec.rb
+++ b/spec/bin/sync_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
-require Rails.root.join('bin/sync').to_s
+require Rails.root.join('bin', 'sync').to_s
 
 RSpec.describe 'bin/sync' do
   let(:entity_source) { create(:entity_source, :external) }

--- a/spec/factories/api_subjects.rb
+++ b/spec/factories/api_subjects.rb
@@ -6,10 +6,10 @@ FactoryBot.define do
     description { Faker::Lorem.sentence }
     contact_name { Faker::Name.name }
     contact_mail { Faker::Internet.email }
-    enabled true
+    enabled { true }
 
     trait :authorized do
-      transient { permission '*' }
+      transient { permission { '*' } }
 
       after(:create) do |api_subject, attrs|
         role = create :role

--- a/spec/factories/attribute_consuming_services.rb
+++ b/spec/factories/attribute_consuming_services.rb
@@ -3,7 +3,7 @@
 FactoryBot.define do
   factory :attribute_consuming_service do
     index { Faker::Number.number digits: 2 }
-    default false
+    default { false }
     sp_sso_descriptor
 
     after(:create) do |acs|

--- a/spec/factories/attribute_profiles.rb
+++ b/spec/factories/attribute_profiles.rb
@@ -2,6 +2,6 @@
 
 FactoryBot.define do
   factory :attribute_profile do
-    uri 'urn:oasis:names:tc:SAML:2.0:profiles:attribute:basic'
+    uri { 'urn:oasis:names:tc:SAML:2.0:profiles:attribute:basic' }
   end
 end

--- a/spec/factories/attributes.rb
+++ b/spec/factories/attributes.rb
@@ -6,7 +6,7 @@ FactoryBot.define do
 
     trait :with_value do
       transient do
-        value Faker::Lorem.word
+        value { Faker::Lorem.word }
       end
 
       after :create do |attr, eval|
@@ -16,7 +16,7 @@ FactoryBot.define do
 
     trait :with_values do
       transient do
-        number_of_values 3
+        number_of_values { 3 }
       end
 
       after :create do |attr, eval|
@@ -35,7 +35,7 @@ FactoryBot.define do
 
     factory :requested_attribute, class: 'RequestedAttribute' do
       reasoning { Faker::Lorem.sentence }
-      required false
+      required { false }
 
       association :attribute_consuming_service
 
@@ -46,7 +46,7 @@ FactoryBot.define do
       end
 
       trait :is_required do
-        required true
+        required { true }
       end
     end
   end

--- a/spec/factories/contact_people.rb
+++ b/spec/factories/contact_people.rb
@@ -2,7 +2,7 @@
 
 FactoryBot.define do
   factory :contact_person do
-    contact_type :technical
+    contact_type { :technical }
     association :contact
 
     trait :without_company do

--- a/spec/factories/encryption_methods.rb
+++ b/spec/factories/encryption_methods.rb
@@ -4,6 +4,6 @@ FactoryBot.define do
   factory :encryption_method do
     key_descriptor
 
-    algorithm 'http://www.w3.org/2001/04/xmlenc#tripledes-cbc'
+    algorithm { 'http://www.w3.org/2001/04/xmlenc#tripledes-cbc' }
   end
 end

--- a/spec/factories/endpoints.rb
+++ b/spec/factories/endpoints.rb
@@ -12,13 +12,13 @@ FactoryBot.define do
 
   trait :indexed_endpoint do
     endpoint
-    is_default false
+    is_default { false }
     index { Faker::Base.numerify '#' }
   end
 
   trait :default_indexed_endpoint do
     indexed_endpoint
-    is_default true
+    is_default { true }
   end
 
   factory :_endpoint, class: 'Endpoint', traits: [:endpoint]

--- a/spec/factories/entity_descriptors.rb
+++ b/spec/factories/entity_descriptors.rb
@@ -2,7 +2,7 @@
 
 FactoryBot.define do
   factory :entity_descriptor do
-    enabled true
+    enabled { true }
 
     association :known_entity
     association :organization

--- a/spec/factories/entity_sources.rb
+++ b/spec/factories/entity_sources.rb
@@ -2,7 +2,7 @@
 
 FactoryBot.define do
   factory :entity_source do
-    enabled true
+    enabled { true }
     # Max BIGINT value + 1, according to MySQL documentation
     rank { rand(9_223_372_036_854_775_808) }
     sequence(:source_tag) { |n| "#{Faker::Lorem.characters(number: 20)}-#{n}" }

--- a/spec/factories/idp_sso_descriptors.rb
+++ b/spec/factories/idp_sso_descriptors.rb
@@ -3,7 +3,7 @@
 FactoryBot.define do
   factory :idp_sso_descriptor, parent: :sso_descriptor,
                                class: 'IDPSSODescriptor' do
-    want_authn_requests_signed false
+    want_authn_requests_signed { false }
 
     after(:create) do |idp|
       idp.add_single_sign_on_service(create(:single_sign_on_service,
@@ -11,7 +11,7 @@ FactoryBot.define do
     end
 
     trait :with_requests_signed do
-      want_authn_requests_signed true
+      want_authn_requests_signed { true }
     end
 
     trait :with_key_descriptors do

--- a/spec/factories/key_descriptors.rb
+++ b/spec/factories/key_descriptors.rb
@@ -9,11 +9,11 @@ FactoryBot.define do
     end
 
     trait :signing do
-      key_type :signing
+      key_type { :signing }
     end
 
     trait :encryption do
-      key_type :encryption
+      key_type { :encryption }
     end
   end
 end

--- a/spec/factories/keypair.rb
+++ b/spec/factories/keypair.rb
@@ -4,7 +4,7 @@ FactoryBot.define do
   test_rsa_keys = {}
 
   factory :rsa_key, class: OpenSSL::PKey::RSA do
-    transient { bits 2048 }
+    transient { bits { 2048 } }
 
     initialize_with do
       test_rsa_keys[bits.to_i] ||= OpenSSL::PKey::RSA.new(bits)
@@ -18,7 +18,7 @@ FactoryBot.define do
       rsa_key { create(:rsa_key) }
       subject_dn { "CN=#{SecureRandom.urlsafe_base64}" }
       issuer_dn { subject_dn }
-      digest_class OpenSSL::Digest::SHA256
+      digest_class { OpenSSL::Digest::SHA256 }
     end
 
     public_key { rsa_key.public_key }
@@ -27,8 +27,8 @@ FactoryBot.define do
 
     not_before { Time.zone.now }
     not_after { 1.hour.from_now }
-    serial 0
-    version 2
+    serial { 0 }
+    version { 2 }
 
     after(:build) do |cert, attr|
       cert.sign(attr.rsa_key, attr.digest_class.new)

--- a/spec/factories/known_entities.rb
+++ b/spec/factories/known_entities.rb
@@ -7,7 +7,7 @@ FactoryBot.define do
     end
 
     association :entity_source
-    enabled true
+    enabled { true }
 
     trait :with_idp do
       after(:create) do |ke|

--- a/spec/factories/localized_names.rb
+++ b/spec/factories/localized_names.rb
@@ -3,6 +3,6 @@
 FactoryBot.define do
   factory :localized_name do
     value { Faker::Lorem.sentence }
-    lang 'en'
+    lang { 'en' }
   end
 end

--- a/spec/factories/localized_uris.rb
+++ b/spec/factories/localized_uris.rb
@@ -3,6 +3,6 @@
 FactoryBot.define do
   factory :localized_uri do
     uri { Faker::Internet.url }
-    lang 'en'
+    lang { 'en' }
   end
 end

--- a/spec/factories/mdattr_entity_attributes.rb
+++ b/spec/factories/mdattr_entity_attributes.rb
@@ -2,17 +2,17 @@
 
 FactoryBot.define do
   factory :mdattr_entity_attribute, class: 'MDATTR::EntityAttribute' do
-    transient { provides_attribute false }
+    transient { provides_attribute { false } }
 
     trait :with_multiple_attributes do
-      transient { provides_attribute true }
+      transient { provides_attribute { true } }
       after(:create) do |ea|
         create_list :attribute, 3, :with_value, entity_attribute: ea
       end
     end
 
     trait :with_refeds_rs_entity_category do
-      transient { provides_attribute true }
+      transient { provides_attribute { true } }
       after(:create) do |ea|
         ea.add_attribute create(:attribute, :with_value,
                                 value: 'http://refeds.org/category/research-and-scholarship',

--- a/spec/factories/mdrpi_usage_policies.rb
+++ b/spec/factories/mdrpi_usage_policies.rb
@@ -3,7 +3,7 @@
 FactoryBot.define do
   factory :mdrpi_usage_policy, class: 'MDRPI::UsagePolicy',
                                parent: :localized_uri do
-    uri 'http://www.edugain.org/policy/metadata-tou_1_0.txt'
+    uri { 'http://www.edugain.org/policy/metadata-tou_1_0.txt' }
     publication_info factory: :mdrpi_publication_info
   end
 end

--- a/spec/factories/mdui_geolocation_hints.rb
+++ b/spec/factories/mdui_geolocation_hints.rb
@@ -2,7 +2,7 @@
 
 FactoryBot.define do
   factory :mdui_geolocation_hint, class: 'MDUI::GeolocationHint' do
-    transient { components(2) }
+    transient { components { 2 } }
 
     uri do
       "geo:#{(1..components).map { Faker::Number.number(digits: 3) }.join(',')}"
@@ -10,7 +10,7 @@ FactoryBot.define do
     association :disco_hints, factory: :mdui_disco_hint
 
     trait :with_altitude do
-      transient { components(3) }
+      transient { components { 3 } }
     end
   end
 end

--- a/spec/factories/metadata_instances.rb
+++ b/spec/factories/metadata_instances.rb
@@ -6,14 +6,14 @@ FactoryBot.define do
 
     name { Faker::Internet.domain_name }
 
-    hash_algorithm 'sha256'
+    hash_algorithm { 'sha256' }
     validity_period { 1.hour }
     cache_period { 6.hours }
     federation_identifier { Faker::Lorem.word }
 
     primary_tag { SecureRandom.urlsafe_base64(16) }
     identifier { SecureRandom.urlsafe_base64(16) }
-    all_entities true
+    all_entities { true }
 
     after :create do |mi|
       create(:mdrpi_publication_info, metadata_instance: mi)

--- a/spec/factories/name_formats.rb
+++ b/spec/factories/name_formats.rb
@@ -2,11 +2,11 @@
 
 FactoryBot.define do
   factory :name_format do
-    uri 'urn:oasis:names:tc:SAML:2.0:attrname-format:unspecified'
+    uri { 'urn:oasis:names:tc:SAML:2.0:attrname-format:unspecified' }
     association :attribute
 
     trait :uri do
-      uri 'urn:oasis:names:tc:SAML:2.0:attrname-format:uri'
+      uri { 'urn:oasis:names:tc:SAML:2.0:attrname-format:uri' }
     end
   end
 end

--- a/spec/factories/name_id_formats.rb
+++ b/spec/factories/name_id_formats.rb
@@ -2,6 +2,6 @@
 
 FactoryBot.define do
   factory :name_id_format do
-    uri 'urn:oasis:names:tc:SAML:2.0:nameid-format:transient'
+    uri { 'urn:oasis:names:tc:SAML:2.0:nameid-format:transient' }
   end
 end

--- a/spec/factories/protocol_supports.rb
+++ b/spec/factories/protocol_supports.rb
@@ -2,7 +2,7 @@
 
 FactoryBot.define do
   factory :protocol_support do
-    uri 'urn:oasis:names:tc:SAML:2.0:protocol'
+    uri { 'urn:oasis:names:tc:SAML:2.0:protocol' }
     association :role_descriptor
   end
 end

--- a/spec/factories/raw_entity_descriptors.rb
+++ b/spec/factories/raw_entity_descriptors.rb
@@ -7,7 +7,7 @@ FactoryBot.define do
       entity_id_uri { "https://#{hostname}/shibboleth" }
     end
 
-    enabled true
+    enabled { true }
 
     association :known_entity
 
@@ -56,7 +56,7 @@ FactoryBot.define do
     end
 
     factory :raw_entity_descriptor_idp do
-      idp true
+      idp { true }
       xml do
         <<-ENTITY.strip_heredoc.strip
           <EntityDescriptor xmlns="urn:oasis:names:tc:SAML:2.0:metadata"
@@ -100,7 +100,7 @@ FactoryBot.define do
     end
 
     factory :raw_entity_descriptor_sp do
-      sp true
+      sp { true }
       xml do
         <<-ENTITY.strip_heredoc.strip
           <EntityDescriptor xmlns="urn:oasis:names:tc:SAML:2.0:metadata"
@@ -151,7 +151,7 @@ FactoryBot.define do
         entity_id_uri { "https://#{hostname}/shibboleth" }
       end
 
-      enabled true
+      enabled { true }
 
       association :known_entity
 
@@ -206,7 +206,7 @@ FactoryBot.define do
         entity_id_uri { "https://#{hostname}/shibboleth" }
       end
 
-      enabled true
+      enabled { true }
 
       association :known_entity
 

--- a/spec/factories/role_descriptors.rb
+++ b/spec/factories/role_descriptors.rb
@@ -3,7 +3,7 @@
 FactoryBot.define do
   factory :role_descriptor do
     entity_descriptor
-    enabled true
+    enabled { true }
 
     after(:create) do |rd|
       rd.add_protocol_support(create(:protocol_support, role_descriptor: rd))

--- a/spec/factories/shibmd_scopes.rb
+++ b/spec/factories/shibmd_scopes.rb
@@ -4,7 +4,7 @@ FactoryBot.define do
   factory :shibmd_scope, class: 'SHIBMD::Scope' do
     association :role_descriptor, factory: :idp_sso_descriptor
     value { Faker::Internet.domain_name }
-    regexp false
-    locked false
+    regexp { false }
+    locked { false }
   end
 end

--- a/spec/factories/sp_sso_descriptors.rb
+++ b/spec/factories/sp_sso_descriptors.rb
@@ -3,8 +3,8 @@
 FactoryBot.define do
   factory :sp_sso_descriptor, parent: :sso_descriptor,
                               class: 'SPSSODescriptor' do
-    authn_requests_signed false
-    want_assertions_signed false
+    authn_requests_signed { false }
+    want_assertions_signed { false }
 
     after(:create) do |sp|
       sp.add_assertion_consumer_service(create(:assertion_consumer_service,
@@ -49,11 +49,11 @@ FactoryBot.define do
     end
 
     trait :with_authn_requests_signed do
-      authn_requests_signed true
+      authn_requests_signed { true }
     end
 
     trait :with_want_assertions_signed do
-      want_assertions_signed true
+      want_assertions_signed { true }
     end
 
     trait :with_multiple_assertion_consumer_services do

--- a/spec/factories/subjects.rb
+++ b/spec/factories/subjects.rb
@@ -4,8 +4,8 @@ FactoryBot.define do
   factory :subject do
     name { Faker::Name.name }
     mail { Faker::Internet.email }
-    enabled true
-    complete true
+    enabled { true }
+    complete { true }
 
     shared_token { SecureRandom.urlsafe_base64(16) }
     targeted_id do
@@ -13,7 +13,7 @@ FactoryBot.define do
     end
 
     trait :authorized do
-      transient { permission '*' }
+      transient { permission { '*' } }
 
       after(:create) do |subject, attrs|
         role = create :role

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -7,7 +7,9 @@ require File.expand_path('../config/environment', __dir__)
 require 'rspec/rails'
 require 'capybara/rails'
 
-Dir[Rails.root.join('spec/support/**/*.rb')].sort.each { |f| require f }
+Dir[Rails.root.join('spec', 'support', '**', '*.rb')].sort.each do |f|
+  require f
+end
 
 Timecop.safe_mode = true
 


### PR DESCRIPTION
Upgrade rubocop to be compatible with the current version of aaf-gumboot.

Resolves the following error:
```
Error: unrecognized cop Style/HashEachMethods found in .rubocop-https---raw-githubusercontent-com-ausaccessfed-aaf-gumboot-develop-aaf-rubocop-yml, unrecognized cop Style/HashTransformKeys found in .rubocop-https---raw-githubusercontent-com-ausaccessfed-aaf-gumboot-develop-aaf-rubocop-yml, unrecognized cop Style/HashTransformValues found in .rubocop-https---raw-githubusercontent-com-ausaccessfed-aaf-gumboot-develop-aaf-rubocop-yml
```

required for https://github.com/ausaccessfed/saml-service/pull/216