### PR TITLE
Fix: SAML: clone re-homed elements to preserve namespaces

### DIFF
--- a/lib/metadata/saml.rb
+++ b/lib/metadata/saml.rb
@@ -237,7 +237,7 @@ module Metadata
       end
 
       parsed_xml.root.elements.each do |element|
-        builder.doc.root << element
+        builder.doc.root << element.clone
       end
     end
 


### PR DESCRIPTION
The code in lib/metadata/saml.rb raw_entity_descriptor creates new root
element and rehomes all existing elements.

In this case, Nokogiri however drops namespace prefixes from element
attributes, changing

    <ContactPerson contactType="other" remd:contactType="http://refeds.org/metadata/contactType/security">

into

    <ContactPerson contactType="other" contactType="http://refeds.org/metadata/contactType/security">

Which renders the XML invalid - and causes a 500 Internal Server error
in the MDQ interface:

```
Metadata::SchemaInvalidError (Metadata is not schema valid [#<Nokogiri::XML::SyntaxError: 120:0: ERROR: Element '{urn:oasis:names:tc:SAML:2.0:metadata}ContactPerson', attribute 'contactType': The attribute 'contactType' is not allowed.>])
```

This affects all MDQ `specific_entity` and `specific_entity_sha1` requests -
if the `EntityDescriptor` has any elements with attributes in a
different namespace.  (And a security contact is such a case).

This is a known issue with Nokogiri: https://github.com/sparklemotion/nokogiri/issues/1200

And the recommended workaround is to clone the elements being rehomed
(tested, works).

All tests pass.