### PR TITLE
Fix: render  ed.extensions in metadata

### DIFF
--- a/lib/metadata/saml.rb
+++ b/lib/metadata/saml.rb
@@ -283,6 +283,7 @@ module Metadata
         publication_info(ed) if root_node
         registration_info(ed)
         entity_attribute(ed.entity_attribute) if ed.entity_attribute?
+        root << ed.extensions if ed.extensions.present?
       end
     end
 

--- a/spec/factories/entity_descriptors.rb
+++ b/spec/factories/entity_descriptors.rb
@@ -12,6 +12,10 @@ FactoryBot.define do
       ed.registration_info = create :mdrpi_registration_info
     end
 
+    trait :with_extensions do
+      extensions { "<some-node>#{Faker::Lorem.paragraph}</some-node>" }
+    end
+
     trait :with_technical_contact do
       after :create do |ed|
         ed.add_contact_person create :contact_person, entity_descriptor: ed

--- a/spec/support/metadata/entity_descriptor.rb
+++ b/spec/support/metadata/entity_descriptor.rb
@@ -6,6 +6,7 @@ RSpec.shared_examples 'EntityDescriptor xml' do
   let(:entity_descriptor_path) { '/EntityDescriptor' }
   let(:extensions_path) { "#{entity_descriptor_path}/Extensions" }
   let(:registration_info_path) { "#{extensions_path}/mdrpi:RegistrationInfo" }
+  let(:test_extensions_path) { "#{extensions_path}/some-node" }
   let(:entity_attributes_path) { "#{extensions_path}/mdattr:EntityAttributes" }
   let(:idp_path) { "#{entity_descriptor_path}/IDPSSODescriptor" }
   let(:sp_path) { "#{entity_descriptor_path}/SPSSODescriptor" }
@@ -72,6 +73,12 @@ RSpec.shared_examples 'EntityDescriptor xml' do
       context 'without EntityAttributes' do
         it 'does not create EntityAttributes node' do
           expect(xml).to have_xpath(entity_attributes_path, count: 0)
+        end
+      end
+      context 'when populated' do
+        let(:entity_descriptor) { create :entity_descriptor, :with_extensions }
+        it 'is rendered' do
+          expect(xml).to have_xpath(test_extensions_path, count: 1)
         end
       end
     end


### PR DESCRIPTION
entity_descriptor_extensions() was not rendering ed.extensions even when present
- add this missing code based on role_descriptor_extensions()

Not immediately needed, just noticed it when exploring the code base and adding it for completeness - otherwise, EntityDescriptor.extensions would be a trap - it would accept data but the data would not be used anywhere.