### PR TITLE
Fix: MetadataQueryController: respect rank in specific_entity methods

### DIFF
--- a/app/controllers/metadata_query_controller.rb
+++ b/app/controllers/metadata_query_controller.rb
@@ -32,17 +32,21 @@ class MetadataQueryController < ApplicationController
   def specific_entity
     public_action
 
-    handle_entity_request(EntityId.first(uri: params[:identifier]))
+    handle_entity_request(select_entity_by_rank(EntityId.where(uri: params[:identifier]).all))
   end
 
   def specific_entity_sha1
     public_action
 
     sha1_identifier = params[:identifier].match(SHA1_REGEX)
-    handle_entity_request(EntityId.first(sha1: sha1_identifier[1]))
+    handle_entity_request(select_entity_by_rank(EntityId.where(sha1: sha1_identifier[1]).all))
   end
 
   private
+
+  def select_entity_by_rank(entity_ids)
+    entity_ids.min_by { |e| e.parent.known_entity.entity_source.rank }
+  end
 
   def handle_entities_request(tags)
     Sequel::Model.db.transaction(isolation: :repeatable) do


### PR DESCRIPTION
Hi,

I've run into an edge-case where the SAML Service served a different version of an Entity then what it should - when accessed via the `specific_entity` / `specific_entity_sha1` MDQ interface.

So here is a fix, with tests for the correct behavior included.

The current behaviour of the `specific_entity` and `specific_entity_sha1` methods in `MetadataQueryController` has been selecting the `.first` EntityId object found (by primary key, `EntityId.id`).

However, when an entity is defined in multiple entity sources, this would pick the first one defined - which would break when an entity is first defined in a lower-priority entity source (eduGAIN) and only later in a high-priority entity source (FR).

So instead explicitly select the EntityId object connected to the lowest rank (highest priority) entity source.

All tests pass.
