### PR TITLE
fix: fr_sync: re-raise exception on validation errors

### DIFF
--- a/app/jobs/concerns/etl/entity_descriptors.rb
+++ b/app/jobs/concerns/etl/entity_descriptors.rb
@@ -24,6 +24,7 @@ module Etl
       rescue Sequel::ValidationFailed => e
         Rails.logger.error "Evicted FR entity #{ed_data[:entity_id]}"
         Rails.logger.error e
+        raise e
       end
     end
 


### PR DESCRIPTION
Hi,
I have been intentionally exploring failure modes possibly coming out of a clash when an entity is both directly registered with the SAML service (via the API) and in Federation Registry.  (This was prep work for migrating an on-prem IdP to our Hosted platform).

First part was OK: I could not register via the API when the IdP was already registered via FR.

But I found an issue in FR sync when I:
* Made the IdP inactive in FR and ran sync
* Registered the IdP via SAML Service API (as a RAW entityDescriptor)
* Made the IdP in FR active again and tried running sync
(This sequence was to confirm what would happen if someone tried reactivating in FR an IdP already migrated to Hosted solution).

The FR sync job noticed the entityID clash and emitted an error message for the IdP, but rolled on with the rest of the sync:
```
E, [2022-05-24T13:52:15.099793 #15043] ERROR -- : Evicted FR entity https://virtualhome.dev.tuakiri.ac.nz/idp/shibboleth
E, [2022-05-24T13:52:15.099924 #15043] ERROR -- : entity_source_id and sha1 is already taken
```

That looked OK - but metadata API then stopped working:
```
[06048ae5-c1bb-4142-924f-87316adf5c27] NoMethodError (undefined method `uri' for nil:NilClass):
[06048ae5-c1bb-4142-924f-87316adf5c27]
[06048ae5-c1bb-4142-924f-87316adf5c27] app/models/known_entity.rb:65:in `entity_id'
[06048ae5-c1bb-4142-924f-87316adf5c27] lib/metadata/saml.rb:101:in `each'
[06048ae5-c1bb-4142-924f-87316adf5c27] lib/metadata/saml.rb:101:in `group_by'
[06048ae5-c1bb-4142-924f-87316adf5c27] lib/metadata/saml.rb:101:in `group_by_eid'
[06048ae5-c1bb-4142-924f-87316adf5c27] lib/metadata/saml.rb:95:in `filter_known_entities'
[06048ae5-c1bb-4142-924f-87316adf5c27] lib/metadata/saml.rb:75:in `known_entity_list'
[06048ae5-c1bb-4142-924f-87316adf5c27] lib/metadata/saml.rb:62:in `block (2 levels) in entities_descriptor'
[06048ae5-c1bb-4142-924f-87316adf5c27] lib/metadata/saml.rb:58:in `block in entities_descriptor'
[06048ae5-c1bb-4142-924f-87316adf5c27] lib/metadata/saml.rb:53:in `entities_descriptor'
[06048ae5-c1bb-4142-924f-87316adf5c27] app/controllers/concerns/metadata_query_caching.rb:61:in `block in cache_known_entities_response'
[06048ae5-c1bb-4142-924f-87316adf5c27] app/controllers/concerns/metadata_query_caching.rb:60:in `cache_known_entities_response'
[06048ae5-c1bb-4142-924f-87316adf5c27] app/controllers/metadata_query_controller.rb:125:in `create_known_entities_response'
[06048ae5-c1bb-4142-924f-87316adf5c27] app/controllers/metadata_query_controller.rb:59:in `block in handle_entities_request'
[06048ae5-c1bb-4142-924f-87316adf5c27] app/controllers/metadata_query_controller.rb:52:in `handle_entities_request'
[06048ae5-c1bb-4142-924f-87316adf5c27] app/controllers/metadata_query_controller.rb:22:in `all_entities'
```

When digging into it, I found the FR sync failed at creating the `EntityId` object, but at that point already created the `KnownEntity` and `EntityDescriptor` objects.  And the `EntityDescriptor` had no `EntityId` object, and that broke metadata publishing.

This was something that required manual cleanup from the Rails console.

Looking into how this could happen in the FR sync, I found that the whole sync runs in a single transaction.  But the code in `app/jobs/concerns/etl/entity_descriptors.rb` catches the `Sequel::ValidationFailed`, logs it, but than just continues on.

So that's how the error happened....

I think the right approach is to re-raise the exception.

In that case, the whole transaction will fail and roll back.

Yes, it would break the full FR sync, but the fix would be easy - just to disable the IdP again via FR UI, and it is better situation than getting corrupted data from a masked failure.

Your thoughts on this one-line fix, @rianniello ?

Cheers,
Vlad

Otherwise, the overall transaction guarding the whole sync may complete,
but leave corrupt data in the database.