### PR TITLE
Optimising the support tests

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -93,17 +93,17 @@ jobs:
           --build-arg DOCKER_ECR=${{ secrets.DOCKER_ECR }} \
           --cache-from $IMAGE_ID:latest -t $IMAGE_ID:$IMAGE_TAG .
 
-      - name: Rubocop
-        run: |
-          docker run \
-            $IMAGE_ID:$IMAGE_TAG \
-            "rubocop -P"
+      # - name: Rubocop
+      #   run: |
+      #     docker run \
+      #       $IMAGE_ID:$IMAGE_TAG \
+      #       "rubocop -P"
 
-      - name: Brakeman
-        run: |
-          docker run \
-            $IMAGE_ID:$IMAGE_TAG \
-            brakeman
+      # - name: Brakeman
+      #   run: |
+      #     docker run \
+      #       $IMAGE_ID:$IMAGE_TAG \
+      #       brakeman
 
       - name: Ensure MySQL is ready
         timeout-minutes: 5

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -93,17 +93,17 @@ jobs:
           --build-arg DOCKER_ECR=${{ secrets.DOCKER_ECR }} \
           --cache-from $IMAGE_ID:latest -t $IMAGE_ID:$IMAGE_TAG .
 
-      # - name: Rubocop
-      #   run: |
-      #     docker run \
-      #       $IMAGE_ID:$IMAGE_TAG \
-      #       "rubocop -P"
+      - name: Rubocop
+        run: |
+          docker run \
+            $IMAGE_ID:$IMAGE_TAG \
+            "rubocop -P"
 
-      # - name: Brakeman
-      #   run: |
-      #     docker run \
-      #       $IMAGE_ID:$IMAGE_TAG \
-      #       brakeman
+      - name: Brakeman
+        run: |
+          docker run \
+            $IMAGE_ID:$IMAGE_TAG \
+            brakeman
 
       - name: Ensure MySQL is ready
         timeout-minutes: 5

--- a/spec/support/jobs/concerns/etl/attribute_authorities.rb
+++ b/spec/support/jobs/concerns/etl/attribute_authorities.rb
@@ -193,7 +193,7 @@ RSpec.shared_examples 'ETL::AttributeAuthorities' do
 
     subject { AttributeAuthorityDescriptor.last }
 
-    it 'creates a new instance' do
+    it 'creates a new instance and tag' do
       expect { run }
         .to change { AttributeAuthorityDescriptor.count }.by(aa_count).and(
           change { Tag.count }.by(1)
@@ -305,7 +305,7 @@ RSpec.shared_examples 'ETL::AttributeAuthorities' do
       end
 
       context 'scopes' do
-        it 'sets a scope' do
+        it 'sets scopes and regex to false' do
           expect(subject.scopes.size).to eq(1)
           expect(subject.scopes.first.value).to eq(scope)
           expect(subject.scopes.first.regexp).not_to be
@@ -397,7 +397,7 @@ RSpec.shared_examples 'ETL::AttributeAuthorities' do
 
     include_examples 'updating a RoleDescriptor'
 
-    it 'uses the existing instance' do
+    it 'uses the existing instance, doesnt create tags, updates' do
       expect { run }.to(not_change { AttributeAuthorityDescriptor.count }.and(
         not_change { Tag.count }
       ).and(

--- a/spec/support/jobs/concerns/etl/attribute_authorities.rb
+++ b/spec/support/jobs/concerns/etl/attribute_authorities.rb
@@ -253,16 +253,8 @@ RSpec.shared_examples 'ETL::AttributeAuthorities' do
       context 'scopes' do
         it 'sets a scope' do
           expect(subject.scopes.size).to eq(1)
-        end
-
-        it 'sets expected scope' do
           expect(subject.scopes.first.value).to eq(scope)
-        end
-
-        context 'normal scope' do
-          it 'sets regex to false' do
-            expect(subject.scopes.first.regexp).not_to be
-          end
+          expect(subject.scopes.first.regexp).not_to be
         end
 
         context 'regex scope' do
@@ -352,28 +344,17 @@ RSpec.shared_examples 'ETL::AttributeAuthorities' do
     include_examples 'updating a RoleDescriptor'
 
     it 'uses the existing instance' do
-      expect { run }.not_to(change { AttributeAuthorityDescriptor.count })
-    end
-
-    it 'does not create more tags' do
-      expect { run }.not_to(change { Tag.count })
-    end
-
-    it 'updates attribute services' do
-      expect { run }.to(change { subject.reload.attribute_services })
-    end
-
-    it 'updates assertion id request services' do
-      expect { run }
-        .to(change { subject.reload.assertion_id_request_services })
-    end
-
-    it 'updates attribute profiles' do
-      expect { run }.to(change { subject.reload.attribute_profiles })
-    end
-
-    it 'updates attributes' do
-      expect { run }.to(change { subject.reload.attributes })
+      expect { run }.to(not_change { AttributeAuthorityDescriptor.count }.and(
+        not_change { Tag.count }
+      ).and(
+        change { subject.reload.attribute_services }
+      ).and(
+        change { subject.reload.assertion_id_request_services }
+      ).and(
+        change { subject.reload.attribute_profiles }
+      ).and(
+        change { subject.reload.attributes }
+      ))
     end
   end
 end

--- a/spec/support/jobs/concerns/etl/attribute_authorities.rb
+++ b/spec/support/jobs/concerns/etl/attribute_authorities.rb
@@ -305,7 +305,7 @@ RSpec.shared_examples 'ETL::AttributeAuthorities' do
       end
 
       context 'scopes' do
-        it 'sets scopes and regex to false' do
+        it 'sets scope and sets regex to false' do
           expect(subject.scopes.size).to eq(1)
           expect(subject.scopes.first.value).to eq(scope)
           expect(subject.scopes.first.regexp).not_to be

--- a/spec/support/jobs/concerns/etl/attribute_authorities.rb
+++ b/spec/support/jobs/concerns/etl/attribute_authorities.rb
@@ -195,7 +195,10 @@ RSpec.shared_examples 'ETL::AttributeAuthorities' do
 
     it 'creates a new instance' do
       expect { run }
-        .to change { AttributeAuthorityDescriptor.count }.by(aa_count)
+        .to change { AttributeAuthorityDescriptor.count }.by(aa_count).and(
+          change { Tag.count }.by(1)
+        )
+      expect(AttributeAuthorityDescriptor.last).to be_valid
     end
 
     context 'when no key type' do
@@ -270,16 +273,6 @@ RSpec.shared_examples 'ETL::AttributeAuthorities' do
       it 'creates a new instance' do
         expect { run }.not_to change(AttributeService, :count)
       end
-    end
-
-    it 'the instance is valid' do
-      run
-      expect(AttributeAuthorityDescriptor.last).to be_valid
-    end
-
-    it 'creates a new tag' do
-      expect { run }
-        .to change { Tag.count }.by(1)
     end
 
     context 'without a scope' do

--- a/spec/support/jobs/concerns/etl/common.rb
+++ b/spec/support/jobs/concerns/etl/common.rb
@@ -118,75 +118,45 @@ RSpec.shared_examples 'ETL::Common' do
   shared_examples 'saml_attributes' do
     it 'has source data' do
       expect(source.count).to be > 0
-    end
-
-    it 'creates new instances' do
       expect(target.count)
         .to eq(source.count)
-    end
-
-    it 'sets name' do
       source.each_with_index do |s, i|
-        expect(target[i].name) == "urn:oid:#{s[:oid]}"
-      end
-    end
-
-    it 'sets friendly_name' do
-      source.each_with_index do |s, i|
-        expect(target[i].friendly_name == s[:name])
-      end
-    end
-
-    it 'sets description' do
-      source.each_with_index do |s, i|
-        expect(target[i].description == s[:description])
-      end
-    end
-
-    it 'sets oid' do
-      source.each_with_index do |s, i|
-        expect(target[i].oid == s[:oid])
+        expect({
+                 description: target[i].description,
+                 oid: target[i].oid,
+                 friendly_name: target[i].friendly_name,
+                 name: target[i].name
+               }).to match({
+                             description: s[:description],
+                             oid: s[:oid],
+                             friendly_name: s[:name],
+                             name: "urn:oid:#{s[:oid]}"
+                           })
       end
     end
   end
 
   shared_examples 'updating a RoleDescriptor' do
     it 're-uses contact instances' do
-      expect { run }.not_to(change { Contact.count })
-    end
-
-    it 'updates contact people' do
-      expect { run }
-        .to(change { subject.entity_descriptor.reload.contact_people })
-    end
-
-    it 'updates sirtfi contact people' do
-      expect { run }
-        .to(change { subject.entity_descriptor.reload.sirtfi_contact_people })
-    end
-
-    it 'updates protocol supports' do
-      expect { run }.to(change { subject.reload.protocol_supports })
-    end
-
-    it 'updates key descriptors' do
-      expect { run }.to(change { subject.reload.key_descriptors })
+      expect { run }.to(not_change { Contact.count }.and(
+        change { subject.entity_descriptor.reload.contact_people }
+      ).and(
+        change { subject.entity_descriptor.reload.sirtfi_contact_people }
+      ).and(
+        change { subject.reload.protocol_supports }
+      ).and(
+        change { subject.reload.key_descriptors }
+      ))
     end
   end
 
   shared_examples 'updating MDUI content' do
     it 'updates mdui display_names' do
-      expect { run }.to(change { subject.reload.ui_info.display_names })
-    end
-
-    it 'updates mdui descriptions' do
-      expect { run }.to(change { subject.reload.ui_info.descriptions })
-    end
-
-    it 'squishes incoming description' do
-      run
-      expect(subject.reload.ui_info.descriptions.first.value)
-        .to eq(description.squish)
+      expect { run }.to(change { subject.reload.ui_info.display_names }.and(
+        change { subject.reload.ui_info.descriptions }
+      ).and(
+        change { subject.reload.ui_info.descriptions.first.value }.to(description.squish)
+      ))
     end
   end
 
@@ -194,19 +164,13 @@ RSpec.shared_examples 'ETL::Common' do
     include_examples 'updating a RoleDescriptor'
 
     it 'updates name id formats' do
-      expect { run }.to(change { subject.reload.name_id_formats })
-    end
-
-    it 'updates artifact resolution services' do
-      expect { run }.to(change { subject.reload.artifact_resolution_services })
-    end
-
-    it 'updates single_logout_services' do
-      expect { run }.to(change { subject.reload.single_logout_services })
-    end
-
-    it 'updates manage name id services' do
-      expect { run }.to(change { subject.reload.manage_name_id_services })
+      expect { run }.to(change { subject.reload.name_id_formats }.and(
+        change { subject.reload.artifact_resolution_services }
+      ).and(
+        change { subject.reload.single_logout_services }
+      ).and(
+        change { subject.reload.manage_name_id_services }
+      ))
     end
   end
 end

--- a/spec/support/jobs/concerns/etl/common.rb
+++ b/spec/support/jobs/concerns/etl/common.rb
@@ -122,7 +122,7 @@ RSpec.shared_examples 'ETL::Common' do
       end
     end
 
-    it 'has source data' do
+    it 'sets rest of data' do
       source.each_with_index do |s, i|
         expect({
                  description: target[i].description,
@@ -141,7 +141,7 @@ RSpec.shared_examples 'ETL::Common' do
   end
 
   shared_examples 'updating a RoleDescriptor' do
-    it 're-uses contact instances' do
+    it 're-uses contact instances, updates contacts, updates protocol and key descriptors' do
       expect { run }.to(not_change { Contact.count }.and(
         change { subject.entity_descriptor.reload.contact_people }
       ).and(
@@ -155,7 +155,7 @@ RSpec.shared_examples 'ETL::Common' do
   end
 
   shared_examples 'updating MDUI content' do
-    it 'updates mdui display_names' do
+    it 'updates mdui display_names and description' do
       expect { run }.to(change { subject.reload.ui_info.display_names }.and(
                           change { subject.reload.ui_info.descriptions }
                         ))
@@ -171,7 +171,7 @@ RSpec.shared_examples 'ETL::Common' do
   shared_examples 'updating an SSODescriptor' do
     include_examples 'updating a RoleDescriptor'
 
-    it 'updates name id formats' do
+    it 'updates name id formats, artifact resolutions and single_logout services' do
       expect { run }.to(change { subject.reload.name_id_formats }.and(
         change { subject.reload.artifact_resolution_services }
       ).and(

--- a/spec/support/jobs/concerns/etl/common.rb
+++ b/spec/support/jobs/concerns/etl/common.rb
@@ -116,23 +116,27 @@ RSpec.shared_examples 'ETL::Common' do
   let(:contacts) { contacts_list }
 
   shared_examples 'saml_attributes' do
+    it 'sets friendly_name' do
+      source.each_with_index do |s, i|
+        expect(target[i].friendly_name == s[:name])
+      end
+    end
+
     it 'has source data' do
-      expect(source.count).to be > 0
-      expect(target.count)
-        .to eq(source.count)
       source.each_with_index do |s, i|
         expect({
                  description: target[i].description,
                  oid: target[i].oid,
-                 friendly_name: target[i].friendly_name,
                  name: target[i].name
                }).to match({
                              description: s[:description],
                              oid: s[:oid],
-                             friendly_name: s[:name],
                              name: "urn:oid:#{s[:oid]}"
                            })
       end
+      expect(source.count).to be > 0
+      expect(target.count)
+        .to eq(source.count)
     end
   end
 
@@ -153,10 +157,14 @@ RSpec.shared_examples 'ETL::Common' do
   shared_examples 'updating MDUI content' do
     it 'updates mdui display_names' do
       expect { run }.to(change { subject.reload.ui_info.display_names }.and(
-        change { subject.reload.ui_info.descriptions }
-      ).and(
-        change { subject.reload.ui_info.descriptions.first.value }.to(description.squish)
-      ))
+                          change { subject.reload.ui_info.descriptions }
+                        ))
+    end
+
+    it 'squishes incoming description' do
+      run
+      expect(subject.reload.ui_info.descriptions.first.value)
+        .to eq(description.squish)
     end
   end
 

--- a/spec/support/jobs/concerns/etl/contact_people.rb
+++ b/spec/support/jobs/concerns/etl/contact_people.rb
@@ -1,39 +1,25 @@
 # frozen_string_literal: true
 
 RSpec.shared_examples 'contact_people' do
-  it 'has source data' do
+  it 'has expected data' do
     expect(source.count).to be > 0
-  end
-
-  it 'creates new instances' do
     expect(target.count)
       .to eq(source.count)
-  end
-
-  it 'has source types' do
     source.each_with_index do |s, i|
       expect(target[i].contact_type.to_s).to eq(s[:type][:name])
-    end
-  end
-
-  it 'has email' do
-    source.each_with_index do |_s, i|
-      expect(target[i].contact.email_address)
-        .to eq(contact_instances[i].email_address)
-    end
-  end
-
-  it 'has given_name' do
-    source.each_with_index do |_s, i|
-      expect(target[i].contact.given_name)
-        .to eq(contact_instances[i].given_name)
-    end
-  end
-
-  it 'has surname' do
-    source.each_with_index do |_s, i|
-      expect(target[i].contact.surname)
-        .to eq(contact_instances[i].surname)
+      expect(
+        {
+          email: target[i].contact.email_address,
+          given_name: target[i].contact.given_name,
+          surname: target[i].contact.surname
+        }
+      ).to match(
+        {
+          email: contact_instances[i].email_address,
+          given_name: contact_instances[i].given_name,
+          surname: contact_instances[i].surname
+        }
+      )
     end
   end
 end

--- a/spec/support/jobs/concerns/etl/endpoints.rb
+++ b/spec/support/jobs/concerns/etl/endpoints.rb
@@ -18,7 +18,7 @@ end
 RSpec.shared_examples 'indexed_endpoint' do
   include_examples 'endpoint'
 
-  it 'expected data' do
+  it 'sets expected data' do
     source.each_with_index do |s, i|
       expect(
         { is_default: target[i].is_default, index: target[i].index }

--- a/spec/support/jobs/concerns/etl/endpoints.rb
+++ b/spec/support/jobs/concerns/etl/endpoints.rb
@@ -1,24 +1,16 @@
 # frozen_string_literal: true
 
 RSpec.shared_examples 'endpoint' do
-  it 'has source data' do
+  it 'expected data' do
     expect(source.count).to be > 0
-  end
-
-  it 'creates new instances' do
     expect(target.count)
       .to eq(source.count)
-  end
-
-  it 'sets expected locations' do
     source.each_with_index do |s, i|
-      expect(target[i].location == s.location)
-    end
-  end
-
-  it 'sets expected bindings' do
-    source.each_with_index do |s, i|
-      expect(target[i].binding == s.binding)
+      expect(
+        { location: target[i].location, binding: target[i].binding }
+      ).to match({
+                   location: s.location, binding: s.binding
+                 })
     end
   end
 end
@@ -26,15 +18,13 @@ end
 RSpec.shared_examples 'indexed_endpoint' do
   include_examples 'endpoint'
 
-  it 'sets is_default' do
+  it 'expected data' do
     source.each_with_index do |s, i|
-      expect(target[i].is_default).to eq(s.is_default)
-    end
-  end
-
-  it 'sets index' do
-    source.each_with_index do |s, i|
-      expect(target[i].index).to eq(s.index)
+      expect(
+        { is_default: target[i].is_default, index: target[i].index }
+      ).to match({
+                   is_default: s.is_default, index: s.index
+                 })
     end
   end
 end

--- a/spec/support/jobs/concerns/etl/endpoints.rb
+++ b/spec/support/jobs/concerns/etl/endpoints.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.shared_examples 'endpoint' do
-  it 'expected data' do
+  it 'sets expected data' do
     expect(source.count).to be > 0
     expect(target.count)
       .to eq(source.count)

--- a/spec/support/jobs/concerns/etl/entity_descriptors.rb
+++ b/spec/support/jobs/concerns/etl/entity_descriptors.rb
@@ -169,25 +169,19 @@ RSpec.shared_examples 'ETL::EntityDescriptors' do
            updated_at: -> { truncated_now })
 
     it 'has entity_id' do
-      expect(subject.entity_id.uri)
-        .to eq(entity_descriptors.last[:entity_id])
-    end
-
-    it 'has registration_authority' do
-      expect(subject.registration_info.registration_authority)
-        .to eq(fr_source.registration_authority)
-    end
-
-    it 'has registration_policy' do
-      expect(subject.registration_info.registration_policies.first.uri)
-        .to eq(fr_source.registration_policy_uri)
-      expect(subject.registration_info.registration_policies.first.lang)
-        .to eq(fr_source.registration_policy_uri_lang)
-    end
-
-    it 'has known_entity with federation tag' do
-      expect(subject.known_entity.tags.first.name)
-        .to eq(subject.known_entity.entity_source.source_tag)
+      expect({
+               entity_id: subject.entity_id.uri,
+               registration_authority: subject.registration_info.registration_authority,
+               registration_policy_uri: subject.registration_info.registration_policies.first.uri,
+               registration_policy_uri_lang: subject.registration_info.registration_policies.first.lang,
+               source_tag: subject.known_entity.tags.first.name
+             }).to match({
+                           entity_id: entity_descriptors.last[:entity_id],
+                           registration_authority: fr_source.registration_authority,
+                           registration_policy_uri: fr_source.registration_policy_uri,
+                           registration_policy_uri_lang: fr_source.registration_policy_uri_lang,
+                           source_tag: subject.known_entity.entity_source.source_tag
+                         })
     end
 
     context 'when services functioning is false' do
@@ -223,15 +217,9 @@ RSpec.shared_examples 'ETL::EntityDescriptors' do
       it 'updates the EntityID uri' do
         expect { run }.to change { subject.reload.entity_id.uri }
           .to eq(updated_entityid)
-      end
-
-      it 'modifies KnownEntity updated_at' do
         Timecop.travel(1.second) do
           expect { run }.to(change { subject.reload.known_entity.updated_at })
         end
-      end
-
-      it 'has known_entity with federation tag' do
         expect(subject.known_entity.tags.first.name)
           .to eq(subject.known_entity.entity_source.source_tag)
       end

--- a/spec/support/jobs/concerns/etl/entity_descriptors.rb
+++ b/spec/support/jobs/concerns/etl/entity_descriptors.rb
@@ -168,7 +168,7 @@ RSpec.shared_examples 'ETL::EntityDescriptors' do
     verify(created_at: -> { ed_created_at },
            updated_at: -> { truncated_now })
 
-    it 'has entity_id' do
+    it 'has entity_id, registration_authority, registration_policy and known_entity with tag' do
       expect({
                entity_id: subject.entity_id.uri,
                registration_authority: subject.registration_info.registration_authority,
@@ -214,7 +214,7 @@ RSpec.shared_examples 'ETL::EntityDescriptors' do
         stub_fr_request(:entity_descriptors)
       end
 
-      it 'updates the EntityID uri' do
+      it 'updates the EntityID uri, KnownEntity and federation tag' do
         expect { run }.to change { subject.reload.entity_id.uri }
           .to eq(updated_entityid)
         Timecop.travel(1.second) do

--- a/spec/support/jobs/concerns/etl/identity_providers.rb
+++ b/spec/support/jobs/concerns/etl/identity_providers.rb
@@ -2,7 +2,7 @@
 
 RSpec.shared_examples 'ETL::IdentityProviders' do
   include_examples 'ETL::Common'
-  # rubocop:disable Metrics/Metrics/AbcSize
+  # rubocop:disable Metrics/MethodLength,Metrics/AbcSize
   def create_json(idp)
     contact_people =
       contact_instances.map { |cp| contact_person_json(cp) } +
@@ -51,7 +51,7 @@ RSpec.shared_examples 'ETL::IdentityProviders' do
       }
     }
   end
-  # rubocop:enable
+  # rubocop:enable  Metrics/MethodLength,Metrics/AbcSize
 
   def attribute_json(a)
     {

--- a/spec/support/jobs/concerns/etl/identity_providers.rb
+++ b/spec/support/jobs/concerns/etl/identity_providers.rb
@@ -205,7 +205,7 @@ RSpec.shared_examples 'ETL::IdentityProviders' do
       end
 
       context 'scopes' do
-        it 'sets a scope and refex to false' do
+        it 'sets a scope with regexp: false' do
           expect(subject.scopes.size).to eq(1)
           expect(subject.scopes.first.value).to eq(scope)
           expect(subject.scopes.first.regexp).not_to be

--- a/spec/support/jobs/concerns/etl/identity_providers.rb
+++ b/spec/support/jobs/concerns/etl/identity_providers.rb
@@ -205,7 +205,7 @@ RSpec.shared_examples 'ETL::IdentityProviders' do
       end
 
       context 'scopes' do
-        it 'sets a scope' do
+        it 'sets a scope and refex to false' do
           expect(subject.scopes.size).to eq(1)
           expect(subject.scopes.first.value).to eq(scope)
           expect(subject.scopes.first.regexp).not_to be
@@ -323,7 +323,7 @@ RSpec.shared_examples 'ETL::IdentityProviders' do
     include_examples 'updating an SSODescriptor'
     include_examples 'updating MDUI content'
 
-    it 'Works as expected' do
+    it 'Works as expected, sets scope, doesnt make tags, updates sso, assertion id, attribute profile and attributes' do
       expect { run }.to(not_change { IDPSSODescriptor.count }.and(
         not_change { Tag.count }
       ).and(

--- a/spec/support/jobs/concerns/etl/identity_providers.rb
+++ b/spec/support/jobs/concerns/etl/identity_providers.rb
@@ -51,7 +51,7 @@ RSpec.shared_examples 'ETL::IdentityProviders' do
       }
     }
   end
-  # rubocop:enable  Metrics/MethodLength,Metrics/AbcSize
+  # rubocop:enable Metrics/MethodLength,Metrics/AbcSize
 
   def attribute_json(a)
     {

--- a/spec/support/jobs/concerns/etl/identity_providers.rb
+++ b/spec/support/jobs/concerns/etl/identity_providers.rb
@@ -2,6 +2,7 @@
 
 RSpec.shared_examples 'ETL::IdentityProviders' do
   include_examples 'ETL::Common'
+  # rubocop:disable Metrics/Metrics/AbcSize
   def create_json(idp)
     contact_people =
       contact_instances.map { |cp| contact_person_json(cp) } +

--- a/spec/support/jobs/concerns/etl/identity_providers.rb
+++ b/spec/support/jobs/concerns/etl/identity_providers.rb
@@ -2,7 +2,6 @@
 
 RSpec.shared_examples 'ETL::IdentityProviders' do
   include_examples 'ETL::Common'
-  # rubocop:disable Metrics/MethodLength,Metrics/AbcSize
   def create_json(idp)
     contact_people =
       contact_instances.map { |cp| contact_person_json(cp) } +
@@ -51,7 +50,7 @@ RSpec.shared_examples 'ETL::IdentityProviders' do
       }
     }
   end
-  # rubocop:enable Metrics/MethodLength,Metrics/AbcSize
+  # rubocop:enable
 
   def attribute_json(a)
     {
@@ -207,16 +206,8 @@ RSpec.shared_examples 'ETL::IdentityProviders' do
       context 'scopes' do
         it 'sets a scope' do
           expect(subject.scopes.size).to eq(1)
-        end
-
-        it 'sets expected scope' do
           expect(subject.scopes.first.value).to eq(scope)
-        end
-
-        context 'normal scope' do
-          it 'sets regex to false' do
-            expect(subject.scopes.first.regexp).not_to be
-          end
+          expect(subject.scopes.first.regexp).not_to be
         end
 
         context 'regex scope' do
@@ -331,41 +322,22 @@ RSpec.shared_examples 'ETL::IdentityProviders' do
     include_examples 'updating an SSODescriptor'
     include_examples 'updating MDUI content'
 
-    it 'uses the existing instance' do
-      expect { run }.not_to(change { IDPSSODescriptor.count })
-    end
-
-    it 'sets a scope' do
+    it 'Works as expected' do
+      expect { run }.to(not_change { IDPSSODescriptor.count }.and(
+        not_change { Tag.count }
+      ).and(
+        change { subject.reload.single_sign_on_services }
+      ).and(
+        change { subject.reload.name_id_mapping_services }
+      ).and(
+        change { subject.reload.assertion_id_request_services }
+      ).and(
+        change { subject.reload.attribute_profiles }
+      ).and(
+        change { subject.reload.attributes }
+      ))
       expect(subject.scopes.size).to eq(1)
-    end
-
-    it 'sets expected scope' do
       expect(subject.scopes.first.value).to eq(scope)
-    end
-
-    it 'does not create more tags' do
-      expect { run }.not_to(change { Tag.count })
-    end
-
-    it 'updates single sign on services' do
-      expect { run }.to(change { subject.reload.single_sign_on_services })
-    end
-
-    it 'updates name id mapping services' do
-      expect { run }.to(change { subject.reload.name_id_mapping_services })
-    end
-
-    it 'updates assertion id request services' do
-      expect { run }
-        .to(change { subject.reload.assertion_id_request_services })
-    end
-
-    it 'updates attribute profiles' do
-      expect { run }.to(change { subject.reload.attribute_profiles })
-    end
-
-    it 'updates attributes' do
-      expect { run }.to(change { subject.reload.attributes })
     end
   end
 

--- a/spec/support/jobs/concerns/etl/identity_providers.rb
+++ b/spec/support/jobs/concerns/etl/identity_providers.rb
@@ -323,7 +323,7 @@ RSpec.shared_examples 'ETL::IdentityProviders' do
     include_examples 'updating an SSODescriptor'
     include_examples 'updating MDUI content'
 
-    it 'Works as expected, sets scope, doesnt make tags, updates sso, assertion id, attribute profile and attributes' do
+    it 'works as expected, sets scope, doesnt make tags, updates sso, assertion id, attribute profile and attributes' do
       expect { run }.to(not_change { IDPSSODescriptor.count }.and(
         not_change { Tag.count }
       ).and(

--- a/spec/support/jobs/concerns/etl/key_descriptors.rb
+++ b/spec/support/jobs/concerns/etl/key_descriptors.rb
@@ -3,41 +3,27 @@
 RSpec.shared_examples 'key_descriptors' do
   it 'has source data' do
     expect(source.count).to be > 0
-  end
-
-  it 'creates new instances' do
     expect(target.count)
       .to eq(source.count)
-  end
-
-  it 'sets type' do
     source.each_with_index do |s, i|
       expect(target[i].key_type).to eq(s.key_type)
     end
   end
 
   context 'key info' do
-    it 'sets key_name' do
+    it 'sets expected data' do
       source.each_with_index do |s, i|
-        expect(target[i].key_info.key_name).to eq(s.key_info.key_name)
-      end
-    end
-
-    it 'sets subject' do
-      source.each_with_index do |s, i|
-        expect(target[i].key_info.subject).to eq(s.key_info.subject)
-      end
-    end
-
-    it 'sets issuer' do
-      source.each_with_index do |s, i|
-        expect(target[i].key_info.issuer).to eq(s.key_info.issuer)
-      end
-    end
-
-    it 'sets certificate PEM data' do
-      source.each_with_index do |s, i|
-        expect(target[i].key_info.data).to eq(s.key_info.data.strip)
+        expect({
+                 key_name: target[i].key_info.key_name,
+                 subject: target[i].key_info.subject,
+                 issuer: target[i].key_info.issuer,
+                 data: target[i].key_info.data
+               }).to match({
+                             key_name: s.key_info.key_name,
+                             subject: s.key_info.subject,
+                             issuer: s.key_info.issuer,
+                             data: s.key_info.data.strip
+                           })
       end
     end
   end

--- a/spec/support/jobs/concerns/etl/organizations.rb
+++ b/spec/support/jobs/concerns/etl/organizations.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.shared_examples 'ETL::Organizations' do
+  # rubocop:disable Metrics/MethodLength
   def create_json(id)
     {
       id: id,
@@ -21,6 +22,7 @@ RSpec.shared_examples 'ETL::Organizations' do
       created_at: fr_time(org_created_at)
     }
   end
+  # rubocop:enable Metrics/MethodLength
 
   let(:org_created_at) { Time.zone.at(rand(Time.now.utc.to_i)) }
   let(:organization_list) do

--- a/spec/support/jobs/concerns/etl/organizations.rb
+++ b/spec/support/jobs/concerns/etl/organizations.rb
@@ -67,7 +67,7 @@ RSpec.shared_examples 'ETL::Organizations' do
 
     it 'has an OrganizationName' do
       expect({
-               domain: subject.organization_names.last.value,
+               entity_id: subject.organization_names.last.value,
                name_lang: subject.organization_names.last.lang,
                display_name: subject.organization_display_names.last.value,
                display_lang: subject.organization_display_names.last.lang,
@@ -75,10 +75,10 @@ RSpec.shared_examples 'ETL::Organizations' do
                lang: subject.organization_urls.last.lang
              }).to match({
                            entity_id: organizations.last[:domain],
-                           registration_authority: organizations.last[:lang],
-                           registration_policy_uri: organizations.last[:display_name],
-                           registration_policy_uri_lang: organizations.last[:lang],
-                           source_tag: organizations.last[:url],
+                           name_lang: organizations.last[:lang],
+                           display_name: organizations.last[:display_name],
+                           display_lang: organizations.last[:lang],
+                           uri: organizations.last[:url],
                            lang: organizations.last[:lang]
                          })
     end
@@ -100,14 +100,14 @@ RSpec.shared_examples 'ETL::Organizations' do
 
       it 'updated created_at' do
         expect { run }
-          .to change { subject.reload.created_at }.to eq(org_created_at).and(
-            change { subject.reload.organization_names.last.value }.to(eq(organizations.last[:domain]))
+          .to change { subject.reload.created_at }.to(org_created_at).and(
+            change { subject.reload.organization_names.last.value }.to(organizations.last[:domain])
           ).and(
             change { subject.reload.organization_display_names.last.value }.to(
-              eq(organizations.last[:display_name])
+              organizations.last[:display_name]
             )
           ).and(
-            change { subject.reload.organization_urls.last.uri }.to(eq(organizations.last[:url]))
+            change { subject.reload.organization_urls.last.uri }.to(organizations.last[:url])
           )
       end
     end

--- a/spec/support/jobs/concerns/etl/organizations.rb
+++ b/spec/support/jobs/concerns/etl/organizations.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.shared_examples 'ETL::Organizations' do
-  # rubocop:disable Metrics/MethodLength
   def create_json(id)
     {
       id: id,
@@ -22,7 +21,6 @@ RSpec.shared_examples 'ETL::Organizations' do
       created_at: fr_time(org_created_at)
     }
   end
-  # rubocop:enable Metrics/MethodLength
 
   let(:org_created_at) { Time.zone.at(rand(Time.now.utc.to_i)) }
   let(:organization_list) do
@@ -66,24 +64,21 @@ RSpec.shared_examples 'ETL::Organizations' do
            updated_at: -> { truncated_now })
 
     it 'has an OrganizationName' do
-      expect(subject.organization_names.last.value)
-        .to eq(organizations.last[:domain])
-      expect(subject.organization_names.last.lang)
-        .to eq(organizations.last[:lang])
-    end
-
-    it 'has an OrganizationDisplayName' do
-      expect(subject.organization_display_names.last.value)
-        .to eq(organizations.last[:display_name])
-      expect(subject.organization_display_names.last.lang)
-        .to eq(organizations.last[:lang])
-    end
-
-    it 'has an OrganizationURL' do
-      expect(subject.organization_urls.last.uri)
-        .to eq(organizations.last[:url])
-      expect(subject.organization_urls.last.lang)
-        .to eq(organizations.last[:lang])
+      expect({
+               domain: subject.organization_names.last.value,
+               name_lang: subject.organization_names.last.lang,
+               display_name: subject.organization_display_names.last.value,
+               display_lang: subject.organization_display_names.last.lang,
+               uri: subject.organization_urls.last.uri,
+               lang: subject.organization_urls.last.lang
+             }).to match({
+                           entity_id: organizations.last[:domain],
+                           registration_authority: organizations.last[:lang],
+                           registration_policy_uri: organizations.last[:display_name],
+                           registration_policy_uri_lang: organizations.last[:lang],
+                           source_tag: organizations.last[:url],
+                           lang: organizations.last[:lang]
+                         })
     end
   end
 
@@ -103,26 +98,15 @@ RSpec.shared_examples 'ETL::Organizations' do
 
       it 'updated created_at' do
         expect { run }
-          .to change { subject.reload.created_at }
-          .to eq(org_created_at)
-      end
-
-      it 'has an OrganizationName' do
-        expect { run }
-          .to change { subject.reload.organization_names.last.value }
-          .to eq(organizations.last[:domain])
-      end
-
-      it 'has an OrganizationDisplayName' do
-        expect { run }
-          .to change { subject.reload.organization_display_names.last.value }
-          .to eq(organizations.last[:display_name])
-      end
-
-      it 'has an OrganizationURL' do
-        expect { run }
-          .to change { subject.reload.organization_urls.last.uri }
-          .to eq(organizations.last[:url])
+          .to change { subject.reload.created_at }.to eq(org_created_at).and(
+            change { subject.reload.organization_names.last.value }.to(eq(organizations.last[:domain]))
+          ).and(
+            change { subject.reload.organization_display_names.last.value }.to(
+              eq(organizations.last[:display_name])
+            )
+          ).and(
+            change { subject.reload.organization_urls.last.uri }.to(eq(organizations.last[:url]))
+          )
       end
     end
   end
@@ -132,22 +116,13 @@ RSpec.shared_examples 'ETL::Organizations' do
 
     shared_examples 'obj creation' do
       it 'creates Organization' do
-        expect { run }.to change { Organization.count }.by(organization_count)
-      end
-
-      it 'creates OrganizationName' do
-        expect { run }
-          .to change { OrganizationName.count }.by(organization_count)
-      end
-
-      it 'creates OrganizationDisplayName' do
-        expect { run }
-          .to change { OrganizationDisplayName.count }.by(organization_count)
-      end
-
-      it 'creates OrganizationURL' do
-        expect { run }
-          .to change { OrganizationURL.count }.by(organization_count)
+        expect { run }.to change { Organization.count }.by(organization_count).and(
+          change { OrganizationName.count }.by(organization_count)
+        ).and(
+          change { OrganizationDisplayName.count }.by(organization_count)
+        ).and(
+          change { OrganizationURL.count }.by(organization_count)
+        )
       end
     end
 

--- a/spec/support/jobs/concerns/etl/organizations.rb
+++ b/spec/support/jobs/concerns/etl/organizations.rb
@@ -65,7 +65,7 @@ RSpec.shared_examples 'ETL::Organizations' do
     verify(created_at: -> { org_created_at },
            updated_at: -> { truncated_now })
 
-    it 'has an OrganizationName' do
+    it 'has an OrganizationName, OrganizationDisplayName and OrganizationURL' do
       expect({
                entity_id: subject.organization_names.last.value,
                name_lang: subject.organization_names.last.lang,
@@ -98,7 +98,7 @@ RSpec.shared_examples 'ETL::Organizations' do
       verify(created_at: -> { subject.created_at },
              updated_at: -> { truncated_now })
 
-      it 'updated created_at' do
+      it 'updated created_at, OrganizationName, OrganizationDisplayName and OrganizationURL' do
         expect { run }
           .to change { subject.reload.created_at }.to(org_created_at).and(
             change { subject.reload.organization_names.last.value }.to(organizations.last[:domain])
@@ -117,7 +117,7 @@ RSpec.shared_examples 'ETL::Organizations' do
     let(:organizations) { organization_list }
 
     shared_examples 'obj creation' do
-      it 'creates Organization' do
+      it 'creates Organization, OrganizationName, OrganizationDisplayName and OrganizationURL' do
         expect { run }.to change { Organization.count }.by(organization_count).and(
           change { OrganizationName.count }.by(organization_count)
         ).and(

--- a/spec/support/jobs/concerns/etl/saml_uri.rb
+++ b/spec/support/jobs/concerns/etl/saml_uri.rb
@@ -1,16 +1,10 @@
 # frozen_string_literal: true
 
 RSpec.shared_examples 'saml_uris' do
-  it 'has source data' do
+  it 'has expected data' do
     expect(source.count).to be > 0
-  end
-
-  it 'creates new instances' do
     expect(target.count)
       .to eq(source.count)
-  end
-
-  it 'sets expected uri' do
     source.each_with_index do |s, i|
       expect(target[i].uri == s.uri)
     end

--- a/spec/support/jobs/concerns/etl/service_providers.rb
+++ b/spec/support/jobs/concerns/etl/service_providers.rb
@@ -193,16 +193,11 @@ RSpec.shared_examples 'ETL::ServiceProviders' do
     subject { SPSSODescriptor.last }
 
     it 'creates a new instance' do
-      expect { run }.to change { SPSSODescriptor.count }.by(sp_count)
-    end
-
-    it 'creates a new tag' do
-      expect { run }
-        .to change { Tag.count }.by(1)
-    end
-
-    it 'creates a new AttributeConsumingService ' do
-      expect { run }.to change { AttributeConsumingService.count }.by(sp_count)
+      expect { run }.to change { SPSSODescriptor.count }.by(sp_count).and(
+        change { Tag.count }.by(1)
+      ).and(
+        change { AttributeConsumingService.count }.by(sp_count)
+      )
     end
 
     context 'when no AttributeConsumingService to add' do
@@ -333,19 +328,15 @@ RSpec.shared_examples 'ETL::ServiceProviders' do
     include_examples 'updating MDUI content'
 
     it 'uses the existing instance' do
-      expect { run }.not_to(change { SPSSODescriptor.count })
-    end
-
-    it 'does not create more tags' do
-      expect { run }.not_to(change { Tag.count })
-    end
-
-    it 'updates assertion_consumer_services' do
-      expect { run }.to(change { subject.reload.assertion_consumer_services })
-    end
-
-    it 'updates discovery_response_services' do
-      expect { run }.to(change { subject.reload.discovery_response_services })
+      expect { run }.to(not_change { SPSSODescriptor.count }.and(
+        not_change { Tag.count }
+      ).and(
+        change { subject.reload.assertion_consumer_services }
+      ).and(
+        change { subject.reload.discovery_response_services }
+      ).and(
+        change { subject.reload.attribute_consuming_services }
+      ))
     end
 
     context 'when no discovery_response_services not functioning' do
@@ -358,10 +349,6 @@ RSpec.shared_examples 'ETL::ServiceProviders' do
       it 'doesnt update discovery_response_services' do
         expect { run }.not_to(change { subject.reload.discovery_response_services })
       end
-    end
-
-    it 'updates attribute_consuming_services' do
-      expect { run }.to(change { subject.reload.attribute_consuming_services })
     end
   end
 end

--- a/spec/support/jobs/concerns/etl/service_providers.rb
+++ b/spec/support/jobs/concerns/etl/service_providers.rb
@@ -359,7 +359,8 @@ RSpec.shared_examples 'ETL::ServiceProviders' do
     include_examples 'updating an SSODescriptor'
     include_examples 'updating MDUI content'
 
-    it 'uses the existing instance, does not create tags, updates assertion_consumer_services and discovery_response_services' do
+    it 'uses the existing instance, does not create tags, updates assertion_consumer_services' \
+       'and discovery_response_services' do
       expect { run }.to(not_change { SPSSODescriptor.count }.and(
         not_change { Tag.count }
       ).and(

--- a/spec/support/jobs/concerns/etl/service_providers.rb
+++ b/spec/support/jobs/concerns/etl/service_providers.rb
@@ -192,7 +192,7 @@ RSpec.shared_examples 'ETL::ServiceProviders' do
 
     subject { SPSSODescriptor.last }
 
-    it 'creates a new instance' do
+    it 'creates a new instance, tag and AttributeConsumingService' do
       expect { run }.to change { SPSSODescriptor.count }.by(sp_count).and(
         change { Tag.count }.by(1)
       ).and(
@@ -359,7 +359,7 @@ RSpec.shared_examples 'ETL::ServiceProviders' do
     include_examples 'updating an SSODescriptor'
     include_examples 'updating MDUI content'
 
-    it 'uses the existing instance' do
+    it 'uses the existing instance, does not create tags, updates assertion_consumer_services and discovery_response_services' do
       expect { run }.to(not_change { SPSSODescriptor.count }.and(
         not_change { Tag.count }
       ).and(

--- a/spec/support/metadata/attribute.rb
+++ b/spec/support/metadata/attribute.rb
@@ -7,7 +7,7 @@ RSpec.shared_examples 'saml:Attribute xml' do
   let(:node) { xml.find(:xpath, attribute_path) }
 
   context 'Attribute' do
-    it 'is created' do
+    it 'is created, sets name and uri' do
       expect(xml).to have_xpath(attribute_path, count: 1)
       expect(node['NameFormat']).to eq(attribute.name_format.uri)
       expect(node['Name']).to eq(attribute.name)
@@ -47,7 +47,7 @@ RSpec.shared_examples 'saml:Attribute xml' do
       end
       context 'Attribute has attribute_values' do
         let(:attribute) { create :attribute, :with_values }
-        it 'is created' do
+        it 'is created and renders expected values' do
           expect(xml).to have_xpath(attribute_value_path, count: 3)
           nodes.each_with_index do |node, i|
             expect(node.text).to eq(attribute.attribute_values[i].value)

--- a/spec/support/metadata/attribute.rb
+++ b/spec/support/metadata/attribute.rb
@@ -9,23 +9,16 @@ RSpec.shared_examples 'saml:Attribute xml' do
   context 'Attribute' do
     it 'is created' do
       expect(xml).to have_xpath(attribute_path, count: 1)
+      expect(node['NameFormat']).to eq(attribute.name_format.uri)
+      expect(node['Name']).to eq(attribute.name)
     end
 
     context 'attributes' do
-      it 'sets Name' do
-        expect(node['Name']).to eq(attribute.name)
-      end
-
       context 'NameFormat' do
         context 'without value' do
           let(:attribute) { create :minimal_attribute }
           it 'is not included' do
             expect(node['NameFormat']).to be_falsey
-          end
-        end
-        context 'with value' do
-          it 'is included' do
-            expect(node['NameFormat']).to eq(attribute.name_format.uri)
           end
         end
       end
@@ -60,9 +53,6 @@ RSpec.shared_examples 'saml:Attribute xml' do
         let(:attribute) { create :attribute, :with_values }
         it 'is created' do
           expect(xml).to have_xpath(attribute_value_path, count: 3)
-        end
-
-        it 'renders expected values' do
           nodes.each_with_index do |node, i|
             expect(node.text).to eq(attribute.attribute_values[i].value)
           end

--- a/spec/support/metadata/attribute.rb
+++ b/spec/support/metadata/attribute.rb
@@ -14,29 +14,25 @@ RSpec.shared_examples 'saml:Attribute xml' do
     end
 
     context 'attributes' do
-      context 'NameFormat' do
-        context 'without value' do
-          let(:attribute) { create :minimal_attribute }
-          it 'is not included' do
-            expect(node['NameFormat']).to be_falsey
-          end
+      context 'NameFormat without value' do
+        let(:attribute) { create :minimal_attribute }
+        it 'is not included' do
+          expect(node['NameFormat']).to be_falsey
         end
       end
 
-      context 'FriendlyName' do
-        context 'without value' do
-          let(:attribute) { create :minimal_attribute }
-          it 'is not included' do
-            expect(node['FriendlyName']).to be_falsey
-          end
+      context 'FriendlyName without value' do
+        let(:attribute) { create :minimal_attribute }
+        it 'is not included' do
+          expect(node['FriendlyName']).to be_falsey
         end
-        context 'with value' do
-          let(:attribute) do
-            create :minimal_attribute, friendly_name: Faker::Lorem.word
-          end
-          it 'is included' do
-            expect(node['FriendlyName']).to eq(attribute.friendly_name)
-          end
+      end
+      context 'with value' do
+        let(:attribute) do
+          create :minimal_attribute, friendly_name: Faker::Lorem.word
+        end
+        it 'is included' do
+          expect(node['FriendlyName']).to eq(attribute.friendly_name)
         end
       end
     end

--- a/spec/support/metadata/attribute_authority_descriptor.rb
+++ b/spec/support/metadata/attribute_authority_descriptor.rb
@@ -68,8 +68,6 @@ RSpec.shared_examples 'AttributeAuthorityDescriptor xml' do
       let(:node) { xml.first(:xpath, name_id_format_path) }
       it 'is rendered' do
         expect(xml).to have_xpath(name_id_format_path, count: 2)
-      end
-      it 'has expected value' do
         expect(node.text)
           .to eq(attribute_authority_descriptor.name_id_formats.first.uri)
       end
@@ -90,8 +88,6 @@ RSpec.shared_examples 'AttributeAuthorityDescriptor xml' do
       let(:node) { xml.first(:xpath, attribute_profile_path) }
       it 'is rendered' do
         expect(xml).to have_xpath(attribute_profile_path, count: 2)
-      end
-      it 'has expected value' do
         expect(node.text)
           .to eq(attribute_authority_descriptor.attribute_profiles.first.uri)
       end
@@ -112,8 +108,6 @@ RSpec.shared_examples 'AttributeAuthorityDescriptor xml' do
       let(:node) { xml.first(:xpath, attribute_path) }
       it 'is rendered' do
         expect(xml).to have_xpath(attribute_path, count: 2)
-      end
-      it 'has expected value' do
         expect(node['Name'])
           .to eq(attribute_authority_descriptor.attributes.first.name)
       end

--- a/spec/support/metadata/attribute_authority_descriptor.rb
+++ b/spec/support/metadata/attribute_authority_descriptor.rb
@@ -66,7 +66,7 @@ RSpec.shared_examples 'AttributeAuthorityDescriptor xml' do
                :with_multiple_name_id_formats
       end
       let(:node) { xml.first(:xpath, name_id_format_path) }
-      it 'is rendered' do
+      it 'is rendered and has expected value' do
         expect(xml).to have_xpath(name_id_format_path, count: 2)
         expect(node.text)
           .to eq(attribute_authority_descriptor.name_id_formats.first.uri)
@@ -86,7 +86,7 @@ RSpec.shared_examples 'AttributeAuthorityDescriptor xml' do
                :with_multiple_attribute_profiles
       end
       let(:node) { xml.first(:xpath, attribute_profile_path) }
-      it 'is rendered' do
+      it 'is rendered and has expected value' do
         expect(xml).to have_xpath(attribute_profile_path, count: 2)
         expect(node.text)
           .to eq(attribute_authority_descriptor.attribute_profiles.first.uri)
@@ -106,7 +106,7 @@ RSpec.shared_examples 'AttributeAuthorityDescriptor xml' do
                :with_multiple_attributes
       end
       let(:node) { xml.first(:xpath, attribute_path) }
-      it 'is rendered' do
+      it 'is rendered and has expected value' do
         expect(xml).to have_xpath(attribute_path, count: 2)
         expect(node['Name'])
           .to eq(attribute_authority_descriptor.attributes.first.name)

--- a/spec/support/metadata/attribute_consuming_service.rb
+++ b/spec/support/metadata/attribute_consuming_service.rb
@@ -20,8 +20,6 @@ RSpec.shared_examples 'AttributeConsumingService xml' do
     context 'index' do
       it 'is rendered' do
         expect(node['index']).to be_truthy
-      end
-      it 'has expected value' do
         expect(node['index']).to eq(attribute_consuming_service.index.to_s)
       end
     end
@@ -29,8 +27,6 @@ RSpec.shared_examples 'AttributeConsumingService xml' do
     context 'isDefault' do
       it 'is rendered' do
         expect(node['isDefault']).to be_truthy
-      end
-      it 'has expected value' do
         expect(node['isDefault'])
           .to eq(attribute_consuming_service.default.to_s)
       end
@@ -47,8 +43,6 @@ RSpec.shared_examples 'AttributeConsumingService xml' do
       context 'lang' do
         it 'is rendered' do
           expect(node['xml:lang']).not_to be_nil
-        end
-        it 'has expected value' do
           expect(node['xml:lang'])
             .to eq(attribute_consuming_service.service_names.first.lang)
         end
@@ -80,8 +74,6 @@ RSpec.shared_examples 'AttributeConsumingService xml' do
       context 'lang' do
         it 'is rendered' do
           expect(node['xml:lang']).not_to be_nil
-        end
-        it 'has expected value' do
           expect(node['xml:lang'])
             .to eq(attribute_consuming_service.service_descriptions.first.lang)
         end

--- a/spec/support/metadata/attribute_consuming_service.rb
+++ b/spec/support/metadata/attribute_consuming_service.rb
@@ -12,6 +12,7 @@ RSpec.shared_examples 'AttributeConsumingService xml' do
   end
   it 'is created' do
     expect(xml).to have_xpath(attribute_consuming_service_path)
+    expect(xml).to have_xpath(requested_attribute_path)
   end
 
   context 'attributes' do
@@ -19,14 +20,12 @@ RSpec.shared_examples 'AttributeConsumingService xml' do
 
     context 'index' do
       it 'is rendered' do
-        expect(node['index']).to be_truthy
         expect(node['index']).to eq(attribute_consuming_service.index.to_s)
       end
     end
 
     context 'isDefault' do
       it 'is rendered' do
-        expect(node['isDefault']).to be_truthy
         expect(node['isDefault'])
           .to eq(attribute_consuming_service.default.to_s)
       end
@@ -42,7 +41,6 @@ RSpec.shared_examples 'AttributeConsumingService xml' do
     context 'attributes' do
       context 'lang' do
         it 'is rendered' do
-          expect(node['xml:lang']).not_to be_nil
           expect(node['xml:lang'])
             .to eq(attribute_consuming_service.service_names.first.lang)
         end
@@ -73,7 +71,6 @@ RSpec.shared_examples 'AttributeConsumingService xml' do
     context 'attributes' do
       context 'lang' do
         it 'is rendered' do
-          expect(node['xml:lang']).not_to be_nil
           expect(node['xml:lang'])
             .to eq(attribute_consuming_service.service_descriptions.first.lang)
         end
@@ -96,10 +93,6 @@ RSpec.shared_examples 'AttributeConsumingService xml' do
   end
 
   context 'RequestedAttributes' do
-    it 'is created' do
-      expect(xml).to have_xpath(requested_attribute_path)
-    end
-
     context 'multiple attributes' do
       let(:attribute_consuming_service) do
         create :attribute_consuming_service, :with_multiple_requested_attributes

--- a/spec/support/metadata/attribute_consuming_service.rb
+++ b/spec/support/metadata/attribute_consuming_service.rb
@@ -21,11 +21,6 @@ RSpec.shared_examples 'AttributeConsumingService xml' do
     context 'index' do
       it 'is rendered' do
         expect(node['index']).to eq(attribute_consuming_service.index.to_s)
-      end
-    end
-
-    context 'isDefault' do
-      it 'is rendered' do
         expect(node['isDefault'])
           .to eq(attribute_consuming_service.default.to_s)
       end
@@ -38,12 +33,10 @@ RSpec.shared_examples 'AttributeConsumingService xml' do
       expect(xml).to have_xpath(service_name_path)
     end
 
-    context 'attributes' do
-      context 'lang' do
-        it 'is rendered' do
-          expect(node['xml:lang'])
-            .to eq(attribute_consuming_service.service_names.first.lang)
-        end
+    context 'attributes lang' do
+      it 'is rendered' do
+        expect(node['xml:lang'])
+          .to eq(attribute_consuming_service.service_names.first.lang)
       end
     end
 
@@ -68,12 +61,10 @@ RSpec.shared_examples 'AttributeConsumingService xml' do
       expect(xml).to have_xpath(service_description_path)
     end
 
-    context 'attributes' do
-      context 'lang' do
-        it 'is rendered' do
-          expect(node['xml:lang'])
-            .to eq(attribute_consuming_service.service_descriptions.first.lang)
-        end
+    context 'attributes lang' do
+      it 'is rendered' do
+        expect(node['xml:lang'])
+          .to eq(attribute_consuming_service.service_descriptions.first.lang)
       end
     end
 

--- a/spec/support/metadata/attribute_consuming_service.rb
+++ b/spec/support/metadata/attribute_consuming_service.rb
@@ -19,7 +19,7 @@ RSpec.shared_examples 'AttributeConsumingService xml' do
     let(:node) { xml.first(:xpath, attribute_consuming_service_path) }
 
     context 'index' do
-      it 'is rendered' do
+      it 'is rendered and has expected value' do
         expect(node['index']).to eq(attribute_consuming_service.index.to_s)
         expect(node['isDefault'])
           .to eq(attribute_consuming_service.default.to_s)

--- a/spec/support/metadata/contact_person.rb
+++ b/spec/support/metadata/contact_person.rb
@@ -27,7 +27,7 @@ RSpec.shared_examples 'ContactPerson xml' do
       end
     end
     context 'when known' do
-      it 'is created has correct value' do
+      it 'is created with correct value' do
         expect(xml).to have_xpath(contact_person_company_path, count: 1)
         expect(node.text).to eq(contact_person.contact.company)
       end

--- a/spec/support/metadata/contact_person.rb
+++ b/spec/support/metadata/contact_person.rb
@@ -43,7 +43,7 @@ RSpec.shared_examples 'ContactPerson xml' do
       end
     end
     context 'when known' do
-      it 'is created has correct value' do
+      it 'is created with correct value' do
         expect(xml).to have_xpath(contact_person_given_name_path, count: 1)
         expect(node.text).to eq(contact_person.contact.given_name)
       end

--- a/spec/support/metadata/contact_person.rb
+++ b/spec/support/metadata/contact_person.rb
@@ -75,7 +75,7 @@ RSpec.shared_examples 'ContactPerson xml' do
       end
     end
     context 'when known' do
-      it 'is created has correct value' do
+      it 'is created with correct value' do
         expect(xml).to have_xpath(contact_person_email_address_path, count: 1)
         expect(node.text)
           .to eq("mailto:#{contact_person.contact.email_address}")

--- a/spec/support/metadata/contact_person.rb
+++ b/spec/support/metadata/contact_person.rb
@@ -27,7 +27,7 @@ RSpec.shared_examples 'ContactPerson xml' do
       end
     end
     context 'when known' do
-      it 'is created' do
+      it 'is created has correct value' do
         expect(xml).to have_xpath(contact_person_company_path, count: 1)
         expect(node.text).to eq(contact_person.contact.company)
       end
@@ -43,7 +43,7 @@ RSpec.shared_examples 'ContactPerson xml' do
       end
     end
     context 'when known' do
-      it 'is created' do
+      it 'is created has correct value' do
         expect(xml).to have_xpath(contact_person_given_name_path, count: 1)
         expect(node.text).to eq(contact_person.contact.given_name)
       end
@@ -59,7 +59,7 @@ RSpec.shared_examples 'ContactPerson xml' do
       end
     end
     context 'when known' do
-      it 'is created' do
+      it 'is created has correct value' do
         expect(xml).to have_xpath(contact_person_surname_path, count: 1)
         expect(node.text).to eq(contact_person.contact.surname)
       end
@@ -75,7 +75,7 @@ RSpec.shared_examples 'ContactPerson xml' do
       end
     end
     context 'when known' do
-      it 'is created' do
+      it 'is created has correct value' do
         expect(xml).to have_xpath(contact_person_email_address_path, count: 1)
         expect(node.text)
           .to eq("mailto:#{contact_person.contact.email_address}")
@@ -92,7 +92,7 @@ RSpec.shared_examples 'ContactPerson xml' do
       end
     end
     context 'when known' do
-      it 'is created' do
+      it 'is created has correct value' do
         expect(xml)
           .to have_xpath(contact_person_telephone_number_path, count: 1)
         expect(node.text).to eq(contact_person.contact.telephone_number)

--- a/spec/support/metadata/contact_person.rb
+++ b/spec/support/metadata/contact_person.rb
@@ -59,7 +59,7 @@ RSpec.shared_examples 'ContactPerson xml' do
       end
     end
     context 'when known' do
-      it 'is created has correct value' do
+      it 'is created with correct value' do
         expect(xml).to have_xpath(contact_person_surname_path, count: 1)
         expect(node.text).to eq(contact_person.contact.surname)
       end

--- a/spec/support/metadata/contact_person.rb
+++ b/spec/support/metadata/contact_person.rb
@@ -92,7 +92,7 @@ RSpec.shared_examples 'ContactPerson xml' do
       end
     end
     context 'when known' do
-      it 'is created has correct value' do
+      it 'is created with correct value' do
         expect(xml)
           .to have_xpath(contact_person_telephone_number_path, count: 1)
         expect(node.text).to eq(contact_person.contact.telephone_number)

--- a/spec/support/metadata/contact_person.rb
+++ b/spec/support/metadata/contact_person.rb
@@ -34,8 +34,6 @@ RSpec.shared_examples 'ContactPerson xml' do
     context 'when known' do
       it 'is created' do
         expect(xml).to have_xpath(contact_person_company_path, count: 1)
-      end
-      it 'has correct value' do
         expect(node.text).to eq(contact_person.contact.company)
       end
     end
@@ -52,8 +50,6 @@ RSpec.shared_examples 'ContactPerson xml' do
     context 'when known' do
       it 'is created' do
         expect(xml).to have_xpath(contact_person_given_name_path, count: 1)
-      end
-      it 'has correct value' do
         expect(node.text).to eq(contact_person.contact.given_name)
       end
     end
@@ -70,8 +66,6 @@ RSpec.shared_examples 'ContactPerson xml' do
     context 'when known' do
       it 'is created' do
         expect(xml).to have_xpath(contact_person_surname_path, count: 1)
-      end
-      it 'has correct value' do
         expect(node.text).to eq(contact_person.contact.surname)
       end
     end
@@ -88,8 +82,6 @@ RSpec.shared_examples 'ContactPerson xml' do
     context 'when known' do
       it 'is created' do
         expect(xml).to have_xpath(contact_person_email_address_path, count: 1)
-      end
-      it 'has correct value with uri prepended' do
         expect(node.text)
           .to eq("mailto:#{contact_person.contact.email_address}")
       end
@@ -108,8 +100,6 @@ RSpec.shared_examples 'ContactPerson xml' do
       it 'is created' do
         expect(xml)
           .to have_xpath(contact_person_telephone_number_path, count: 1)
-      end
-      it 'has correct value' do
         expect(node.text).to eq(contact_person.contact.telephone_number)
       end
     end

--- a/spec/support/metadata/contact_person.rb
+++ b/spec/support/metadata/contact_person.rb
@@ -15,12 +15,7 @@ RSpec.shared_examples 'ContactPerson xml' do
 
   it 'is created' do
     expect(xml).to have_xpath(contact_person_path, count: 1)
-  end
-
-  context 'attributes' do
-    it 'sets contactType' do
-      expect(node['contactType']).to eq(contact_person.contact_type.to_s)
-    end
+    expect(node['contactType']).to eq(contact_person.contact_type.to_s)
   end
 
   context 'Company' do

--- a/spec/support/metadata/endpoint.rb
+++ b/spec/support/metadata/endpoint.rb
@@ -7,7 +7,7 @@ RSpec.shared_examples 'Endpoint xml' do
 
   context 'attributes' do
     let(:node) { xml.first(:xpath, endpoint_path) }
-    it 'has binding, location' do
+    it 'has binding and location' do
       expect(node['Binding']).to eq(endpoint.binding)
       expect(node['Location']).to eq(endpoint.location)
       expect(xml).not_to have_xpath("#{endpoint_path}[@ResponseLocation]")

--- a/spec/support/metadata/endpoint.rb
+++ b/spec/support/metadata/endpoint.rb
@@ -14,7 +14,7 @@ RSpec.shared_examples 'Endpoint xml' do
     end
     context 'ResponseLocation when populated' do
       let(:endpoint) { create parent_node, :response_location }
-      it 'is rendered, location' do
+      it 'is rendered and has location' do
         expect(xml).to have_xpath("#{endpoint_path}[@ResponseLocation]")
         expect(node['ResponseLocation']).to eq(endpoint.response_location)
       end

--- a/spec/support/metadata/endpoint.rb
+++ b/spec/support/metadata/endpoint.rb
@@ -7,14 +7,14 @@ RSpec.shared_examples 'Endpoint xml' do
 
   context 'attributes' do
     let(:node) { xml.first(:xpath, endpoint_path) }
-    it 'has expected value' do
+    it 'has binding, location' do
       expect(node['Binding']).to eq(endpoint.binding)
       expect(node['Location']).to eq(endpoint.location)
       expect(xml).not_to have_xpath("#{endpoint_path}[@ResponseLocation]")
     end
     context 'ResponseLocation when populated' do
       let(:endpoint) { create parent_node, :response_location }
-      it 'is rendered' do
+      it 'is rendered, location' do
         expect(xml).to have_xpath("#{endpoint_path}[@ResponseLocation]")
         expect(node['ResponseLocation']).to eq(endpoint.response_location)
       end

--- a/spec/support/metadata/endpoint.rb
+++ b/spec/support/metadata/endpoint.rb
@@ -7,28 +7,16 @@ RSpec.shared_examples 'Endpoint xml' do
 
   context 'attributes' do
     let(:node) { xml.first(:xpath, endpoint_path) }
-    context 'Binding' do
-      it 'has expected value' do
-        expect(node['Binding']).to eq(endpoint.binding)
-      end
-    end
-    context 'Location' do
-      it 'has expected value' do
-        expect(node['Location']).to eq(endpoint.location)
-      end
+    it 'has expected value' do
+      expect(node['Binding']).to eq(endpoint.binding)
+      expect(node['Location']).to eq(endpoint.location)
+      expect(xml).not_to have_xpath("#{endpoint_path}[@ResponseLocation]")
     end
     context 'ResponseLocation' do
-      context 'when not populated' do
-        it 'is not rendered' do
-          expect(xml).not_to have_xpath("#{endpoint_path}[@ResponseLocation]")
-        end
-      end
       context 'when populated' do
         let(:endpoint) { create parent_node, :response_location }
         it 'is rendered' do
           expect(xml).to have_xpath("#{endpoint_path}[@ResponseLocation]")
-        end
-        it 'has expected value' do
           expect(node['ResponseLocation']).to eq(endpoint.response_location)
         end
       end
@@ -51,8 +39,6 @@ RSpec.shared_examples 'IndexedEndpoint xml' do
       let(:endpoint) { create parent_node, :default_indexed_endpoint }
       it 'is rendered' do
         expect(xml).to have_xpath("#{endpoint_path}[@isDefault]")
-      end
-      it 'has expected value' do
         expect(node['isDefault']).to eq(endpoint.is_default.to_s)
       end
     end

--- a/spec/support/metadata/endpoint.rb
+++ b/spec/support/metadata/endpoint.rb
@@ -12,7 +12,7 @@ RSpec.shared_examples 'Endpoint xml' do
       expect(node['Location']).to eq(endpoint.location)
       expect(xml).not_to have_xpath("#{endpoint_path}[@ResponseLocation]")
     end
-    context 'ResponseLocation when populated' do
+    context 'when ResponseLocation is populated' do
       let(:endpoint) { create parent_node, :response_location }
       it 'is rendered and has location' do
         expect(xml).to have_xpath("#{endpoint_path}[@ResponseLocation]")

--- a/spec/support/metadata/endpoint.rb
+++ b/spec/support/metadata/endpoint.rb
@@ -12,13 +12,11 @@ RSpec.shared_examples 'Endpoint xml' do
       expect(node['Location']).to eq(endpoint.location)
       expect(xml).not_to have_xpath("#{endpoint_path}[@ResponseLocation]")
     end
-    context 'ResponseLocation' do
-      context 'when populated' do
-        let(:endpoint) { create parent_node, :response_location }
-        it 'is rendered' do
-          expect(xml).to have_xpath("#{endpoint_path}[@ResponseLocation]")
-          expect(node['ResponseLocation']).to eq(endpoint.response_location)
-        end
+    context 'ResponseLocation when populated' do
+      let(:endpoint) { create parent_node, :response_location }
+      it 'is rendered' do
+        expect(xml).to have_xpath("#{endpoint_path}[@ResponseLocation]")
+        expect(node['ResponseLocation']).to eq(endpoint.response_location)
       end
     end
   end

--- a/spec/support/metadata/entities_descriptor.rb
+++ b/spec/support/metadata/entities_descriptor.rb
@@ -39,7 +39,7 @@ RSpec.shared_examples 'EntitiesDescriptor xml' do
 
       around { |example| Timecop.freeze { example.run } }
 
-      it 'sets ID and name and validuntil' do
+      it 'sets ID, name and validuntil' do
         expect(node['ID']).to eq(subject.instance_id)
           .and start_with(federation_identifier)
         expect(node['Name']).to eq(metadata_name)

--- a/spec/support/metadata/entities_descriptor.rb
+++ b/spec/support/metadata/entities_descriptor.rb
@@ -29,7 +29,7 @@ RSpec.shared_examples 'EntitiesDescriptor xml' do
     include_examples 'shibmd:KeyAuthority xml'
     include_examples 'md:EntitiesDescriptor xml'
 
-    it 'defines namespaces' do
+    it 'defines namespaces and mdrpi:PublisherInfo' do
       expect(namespaces).to eq(Metadata::Saml::NAMESPACES)
       expect(xml).to have_xpath(all_publication_infos, count: 1)
     end
@@ -39,7 +39,7 @@ RSpec.shared_examples 'EntitiesDescriptor xml' do
 
       around { |example| Timecop.freeze { example.run } }
 
-      it 'sets ID' do
+      it 'sets ID and name and validuntil' do
         expect(node['ID']).to eq(subject.instance_id)
           .and start_with(federation_identifier)
         expect(node['Name']).to eq(metadata_name)

--- a/spec/support/metadata/entities_descriptor.rb
+++ b/spec/support/metadata/entities_descriptor.rb
@@ -41,11 +41,7 @@ RSpec.shared_examples 'EntitiesDescriptor xml' do
       it 'sets ID' do
         expect(node['ID']).to eq(subject.instance_id)
           .and start_with(federation_identifier)
-      end
-      it 'sets Name' do
         expect(node['Name']).to eq(metadata_name)
-      end
-      it 'sets validUntil' do
         expect(node['validUntil'])
           .to eq((Time.now.utc + metadata_validity_period).xmlschema)
       end

--- a/spec/support/metadata/entities_descriptor.rb
+++ b/spec/support/metadata/entities_descriptor.rb
@@ -31,6 +31,7 @@ RSpec.shared_examples 'EntitiesDescriptor xml' do
 
     it 'defines namespaces' do
       expect(namespaces).to eq(Metadata::Saml::NAMESPACES)
+      expect(xml).to have_xpath(all_publication_infos, count: 1)
     end
 
     context 'attributes' do
@@ -44,12 +45,6 @@ RSpec.shared_examples 'EntitiesDescriptor xml' do
         expect(node['Name']).to eq(metadata_name)
         expect(node['validUntil'])
           .to eq((Time.now.utc + metadata_validity_period).xmlschema)
-      end
-    end
-
-    context 'Extensions' do
-      it 'creates a mdrpi:PublisherInfo' do
-        expect(xml).to have_xpath(all_publication_infos, count: 1)
       end
     end
   end

--- a/spec/support/metadata/entities_descriptor_xml.rb
+++ b/spec/support/metadata/entities_descriptor_xml.rb
@@ -23,21 +23,15 @@ RSpec.shared_examples 'md:EntitiesDescriptor xml' do
         expect(xml).to have_xpath(registration_info_path, count: 1)
       end
     end
-    context 'RegistrationInfo not set' do
-      it 'does not create RegistrationInfo node' do
-        expect(xml).to have_xpath(registration_info_path, count: 0)
-      end
+    it 'does not create RegistrationInfo node' do
+      expect(xml).to have_xpath(registration_info_path, count: 0)
+      expect(xml).to have_xpath(entity_attributes_path, count: 0)
     end
 
     context 'with EntityAttributes' do
       let(:add_entity_attributes) { true }
       it 'creates EntityAttributes node' do
         expect(xml).to have_xpath(entity_attributes_path, count: 1)
-      end
-    end
-    context 'without EntityAttributes' do
-      it 'does not create EntityAttributes node' do
-        expect(xml).to have_xpath(entity_attributes_path, count: 0)
       end
     end
   end

--- a/spec/support/metadata/entities_descriptor_xml.rb
+++ b/spec/support/metadata/entities_descriptor_xml.rb
@@ -4,7 +4,7 @@ RSpec.shared_examples 'md:EntitiesDescriptor xml' do
   let(:schema) { Nokogiri::XML::Schema.new(File.open('schema/top.xsd', 'r')) }
   let(:validation_errors) { schema.validate(Nokogiri::XML.parse(raw_xml)) }
 
-  it 'is schema-valid' do
+  it 'is schema-valid and created, child EntityDescriptors, no RegistrationInfo node, no EntityAttributes node' do
     expect(validation_errors).to be_empty
     expect(xml).to have_xpath(entities_descriptor_path)
     expect(xml).to have_xpath(entity_descriptor_path, count: 5)

--- a/spec/support/metadata/entities_descriptor_xml.rb
+++ b/spec/support/metadata/entities_descriptor_xml.rb
@@ -6,14 +6,10 @@ RSpec.shared_examples 'md:EntitiesDescriptor xml' do
 
   it 'is schema-valid' do
     expect(validation_errors).to be_empty
-  end
-
-  it 'is created' do
     expect(xml).to have_xpath(entities_descriptor_path)
-  end
-
-  it 'renders child EntityDescriptors' do
     expect(xml).to have_xpath(entity_descriptor_path, count: 5)
+    expect(xml).to have_xpath(registration_info_path, count: 0)
+    expect(xml).to have_xpath(entity_attributes_path, count: 0)
   end
 
   context 'Extensions' do
@@ -22,10 +18,6 @@ RSpec.shared_examples 'md:EntitiesDescriptor xml' do
       it 'creates RegistrationInfo node' do
         expect(xml).to have_xpath(registration_info_path, count: 1)
       end
-    end
-    it 'does not create RegistrationInfo node' do
-      expect(xml).to have_xpath(registration_info_path, count: 0)
-      expect(xml).to have_xpath(entity_attributes_path, count: 0)
     end
 
     context 'with EntityAttributes' do

--- a/spec/support/metadata/entity_descriptor.rb
+++ b/spec/support/metadata/entity_descriptor.rb
@@ -48,7 +48,7 @@ RSpec.shared_examples 'EntityDescriptor xml' do
 
   RSpec.shared_examples 'md:EntityDescriptor xml' do
     let(:create_idp) { true } # Ensure ED is valid to pass #functioning?
-    it 'is created' do
+    it 'is created, RegistrationInfo node, no EntityAttributes node, IDPSSODescriptor node, AttributeAuthorityDescriptor node, creates Organization, creates technical contact' do
       expect(xml).to have_xpath(entity_descriptor_path)
       expect(xml).to have_xpath(registration_info_path, count: 1)
       expect(xml).to have_xpath(entity_attributes_path, count: 0)
@@ -180,7 +180,7 @@ RSpec.shared_examples 'EntityDescriptor xml' do
     context 'attributes' do
       let(:node) { xml.find(:xpath, entity_descriptor_path) }
 
-      it 'sets ID' do
+      it 'sets ID, validuntil' do
         expect(node['ID']).to be_falsey
         expect(node['validUntil']).to be_falsey
       end

--- a/spec/support/metadata/entity_descriptor.rb
+++ b/spec/support/metadata/entity_descriptor.rb
@@ -48,7 +48,8 @@ RSpec.shared_examples 'EntityDescriptor xml' do
 
   RSpec.shared_examples 'md:EntityDescriptor xml' do
     let(:create_idp) { true } # Ensure ED is valid to pass #functioning?
-    it 'is created, RegistrationInfo node, no EntityAttributes node, IDPSSODescriptor node, AttributeAuthorityDescriptor node, creates Organization, creates technical contact' do
+    it 'is created, RegistrationInfo node, no EntityAttributes node, IDPSSODescriptor node,' \
+       'AttributeAuthorityDescriptor node, creates Organization, creates technical contact' do
       expect(xml).to have_xpath(entity_descriptor_path)
       expect(xml).to have_xpath(registration_info_path, count: 1)
       expect(xml).to have_xpath(entity_attributes_path, count: 0)

--- a/spec/support/metadata/entity_descriptor.rb
+++ b/spec/support/metadata/entity_descriptor.rb
@@ -54,6 +54,7 @@ RSpec.shared_examples 'EntityDescriptor xml' do
       expect(xml).to have_xpath(entity_attributes_path, count: 0)
       expect(xml).to have_xpath(organization_path, count: 1)
       expect(xml).to have_xpath(technical_contact_path, count: 1)
+      expect(xml).to have_xpath(idp_path, count: 1)
     end
 
     context 'attributes' do
@@ -79,12 +80,6 @@ RSpec.shared_examples 'EntityDescriptor xml' do
     end
 
     context 'RoleDescriptors' do
-      context 'IDPSSODescriptor' do
-        it 'creates IDPSSODescriptor node' do
-          expect(xml).to have_xpath(idp_path, count: 1)
-        end
-      end
-
       context 'SPSSODescriptor' do
         let(:create_idp) { false }
         let(:create_sp) { true }
@@ -106,8 +101,6 @@ RSpec.shared_examples 'EntityDescriptor xml' do
         let(:create_aa) { true }
         it 'creates IDPSSODescriptor node' do
           expect(xml).to have_xpath(idp_path, count: 1)
-        end
-        it 'creates AttributeAuthorityDescriptor node' do
           expect(xml).to have_xpath(aad_path, count: 1)
         end
       end

--- a/spec/support/metadata/entity_descriptor.rb
+++ b/spec/support/metadata/entity_descriptor.rb
@@ -50,6 +50,10 @@ RSpec.shared_examples 'EntityDescriptor xml' do
     let(:create_idp) { true } # Ensure ED is valid to pass #functioning?
     it 'is created' do
       expect(xml).to have_xpath(entity_descriptor_path)
+      expect(xml).to have_xpath(registration_info_path, count: 1)
+      expect(xml).to have_xpath(entity_attributes_path, count: 0)
+      expect(xml).to have_xpath(organization_path, count: 1)
+      expect(xml).to have_xpath(technical_contact_path, count: 1)
     end
 
     context 'attributes' do
@@ -60,19 +64,10 @@ RSpec.shared_examples 'EntityDescriptor xml' do
     end
 
     context 'Extensions' do
-      it 'creates RegistrationInfo node' do
-        expect(xml).to have_xpath(registration_info_path, count: 1)
-      end
-
       context 'with EntityAttributes' do
         let(:add_entity_attributes) { true }
         it 'creates EntityAttributes node' do
           expect(xml).to have_xpath(entity_attributes_path, count: 1)
-        end
-      end
-      context 'without EntityAttributes' do
-        it 'does not create EntityAttributes node' do
-          expect(xml).to have_xpath(entity_attributes_path, count: 0)
         end
       end
       context 'when populated' do
@@ -148,13 +143,6 @@ RSpec.shared_examples 'EntityDescriptor xml' do
         end
       end
     end
-
-    it 'creates an Organization' do
-      expect(xml).to have_xpath(organization_path, count: 1)
-    end
-    it 'creates a technical contact' do
-      expect(xml).to have_xpath(technical_contact_path, count: 1)
-    end
   end
 
   context 'Root EntityDescriptor' do
@@ -169,8 +157,6 @@ RSpec.shared_examples 'EntityDescriptor xml' do
       it 'sets ID' do
         expect(node['ID']).to eq(subject.instance_id)
           .and start_with(federation_identifier)
-      end
-      it 'sets validUntil' do
         expect(node['validUntil'])
           .to eq((Time.now.utc + metadata_validity_period).xmlschema)
       end
@@ -203,8 +189,6 @@ RSpec.shared_examples 'EntityDescriptor xml' do
 
       it 'sets ID' do
         expect(node['ID']).to be_falsey
-      end
-      it 'sets validUntil' do
         expect(node['validUntil']).to be_falsey
       end
     end

--- a/spec/support/metadata/idp_sso_descriptor.rb
+++ b/spec/support/metadata/idp_sso_descriptor.rb
@@ -20,7 +20,7 @@ RSpec.shared_examples 'IDPSSODescriptor xml' do
     "#{idp_sso_descriptor_path}/Extensions/mdui:DiscoHints"
   end
 
-  it 'is created' do
+  it 'is created, no WantAuthnRequestsSigned, no NameIDMappingServices, no AssertionIDRequestServices, no AttributeProfiles, no mdui:DiscoHints' do
     expect(xml).to have_xpath(idp_sso_descriptor_path)
     expect(node['WantAuthnRequestsSigned']).to be_falsey
     expect(xml).to have_xpath(single_sign_on_service_path, count: 1)

--- a/spec/support/metadata/idp_sso_descriptor.rb
+++ b/spec/support/metadata/idp_sso_descriptor.rb
@@ -20,7 +20,8 @@ RSpec.shared_examples 'IDPSSODescriptor xml' do
     "#{idp_sso_descriptor_path}/Extensions/mdui:DiscoHints"
   end
 
-  it 'is created, no WantAuthnRequestsSigned, no NameIDMappingServices, no AssertionIDRequestServices, no AttributeProfiles, no mdui:DiscoHints' do
+  it 'is created, no WantAuthnRequestsSigned, no NameIDMappingServices,' \
+     'no AssertionIDRequestServices, no AttributeProfiles, no mdui:DiscoHints' do
     expect(xml).to have_xpath(idp_sso_descriptor_path)
     expect(node['WantAuthnRequestsSigned']).to be_falsey
     expect(xml).to have_xpath(single_sign_on_service_path, count: 1)

--- a/spec/support/metadata/idp_sso_descriptor.rb
+++ b/spec/support/metadata/idp_sso_descriptor.rb
@@ -22,23 +22,18 @@ RSpec.shared_examples 'IDPSSODescriptor xml' do
 
   it 'is created' do
     expect(xml).to have_xpath(idp_sso_descriptor_path)
+    expect(node['WantAuthnRequestsSigned']).to be_falsey
+    expect(xml).to have_xpath(single_sign_on_service_path, count: 1)
+    expect(xml).not_to have_xpath(name_id_mapping_service_path)
+    expect(xml).not_to have_xpath(assertion_id_request_service_path)
+    expect(xml).not_to have_xpath(attribute_profile_path)
+    expect(xml).not_to have_xpath(attribute_path)
+    expect(xml).not_to have_xpath(mdui_disco_hints_path)
   end
 
   let(:node) { xml.first(:xpath, idp_sso_descriptor_path) }
 
-  context 'attributes' do
-    context 'WantAuthnRequestsSigned' do
-      it 'is not rendered' do
-        expect(node['WantAuthnRequestsSigned']).to be_falsey
-      end
-    end
-  end
-
   context 'SingleSignOnServices' do
-    it 'is rendered' do
-      expect(xml).to have_xpath(single_sign_on_service_path, count: 1)
-    end
-
     context 'multiple endpoints' do
       let(:idp_sso_descriptor) do
         create :idp_sso_descriptor, :with_multiple_single_sign_on_services
@@ -50,11 +45,6 @@ RSpec.shared_examples 'IDPSSODescriptor xml' do
   end
 
   context 'NameIDMappingServices' do
-    context 'when not populated' do
-      it 'is not rendered' do
-        expect(xml).not_to have_xpath(name_id_mapping_service_path)
-      end
-    end
     context 'when populated' do
       let(:idp_sso_descriptor) do
         create :idp_sso_descriptor, :with_name_id_mapping_services
@@ -66,11 +56,6 @@ RSpec.shared_examples 'IDPSSODescriptor xml' do
   end
 
   context 'AssertionIDRequestServices' do
-    context 'when not populated' do
-      it 'is not rendered' do
-        expect(xml).not_to have_xpath(assertion_id_request_service_path)
-      end
-    end
     context 'when populated' do
       let(:idp_sso_descriptor) do
         create :idp_sso_descriptor, :with_assertion_id_request_services
@@ -82,11 +67,6 @@ RSpec.shared_examples 'IDPSSODescriptor xml' do
   end
 
   context 'AttributeProfiles' do
-    context 'when not populated' do
-      it 'is not rendered' do
-        expect(xml).not_to have_xpath(attribute_profile_path)
-      end
-    end
     context 'when populated' do
       let(:node) { xml.first(:xpath, attribute_profile_path) }
       let(:idp_sso_descriptor) do
@@ -102,11 +82,6 @@ RSpec.shared_examples 'IDPSSODescriptor xml' do
   end
 
   context 'Attributes' do
-    context 'when not populated' do
-      it 'is not rendered' do
-        expect(xml).not_to have_xpath(attribute_path)
-      end
-    end
     context 'when populated' do
       let(:idp_sso_descriptor) do
         create :idp_sso_descriptor, :with_attributes
@@ -118,11 +93,6 @@ RSpec.shared_examples 'IDPSSODescriptor xml' do
   end
 
   context 'mdui:DiscoHints' do
-    context 'when not populated' do
-      it 'is not rendered' do
-        expect(xml).not_to have_xpath(mdui_disco_hints_path)
-      end
-    end
     context 'when populated' do
       let(:idp_sso_descriptor) do
         create :idp_sso_descriptor, :with_disco_hints

--- a/spec/support/metadata/idp_sso_descriptor.rb
+++ b/spec/support/metadata/idp_sso_descriptor.rb
@@ -33,73 +33,59 @@ RSpec.shared_examples 'IDPSSODescriptor xml' do
 
   let(:node) { xml.first(:xpath, idp_sso_descriptor_path) }
 
-  context 'SingleSignOnServices' do
-    context 'multiple endpoints' do
-      let(:idp_sso_descriptor) do
-        create :idp_sso_descriptor, :with_multiple_single_sign_on_services
-      end
-      it 'renders all' do
-        expect(xml).to have_xpath(single_sign_on_service_path, count: 3)
-      end
+  context 'SingleSignOnServices multiple endpoints' do
+    let(:idp_sso_descriptor) do
+      create :idp_sso_descriptor, :with_multiple_single_sign_on_services
+    end
+    it 'renders all' do
+      expect(xml).to have_xpath(single_sign_on_service_path, count: 3)
     end
   end
 
-  context 'NameIDMappingServices' do
-    context 'when populated' do
-      let(:idp_sso_descriptor) do
-        create :idp_sso_descriptor, :with_name_id_mapping_services
-      end
-      it 'is rendered' do
-        expect(xml).to have_xpath(name_id_mapping_service_path, count: 2)
-      end
+  context 'NameIDMappingServices when populated' do
+    let(:idp_sso_descriptor) do
+      create :idp_sso_descriptor, :with_name_id_mapping_services
+    end
+    it 'is rendered' do
+      expect(xml).to have_xpath(name_id_mapping_service_path, count: 2)
     end
   end
 
-  context 'AssertionIDRequestServices' do
-    context 'when populated' do
-      let(:idp_sso_descriptor) do
-        create :idp_sso_descriptor, :with_assertion_id_request_services
-      end
-      it 'is rendered' do
-        expect(xml).to have_xpath(assertion_id_request_service_path, count: 2)
-      end
+  context 'AssertionIDRequestServices when populated' do
+    let(:idp_sso_descriptor) do
+      create :idp_sso_descriptor, :with_assertion_id_request_services
+    end
+    it 'is rendered' do
+      expect(xml).to have_xpath(assertion_id_request_service_path, count: 2)
     end
   end
 
-  context 'AttributeProfiles' do
-    context 'when populated' do
-      let(:node) { xml.first(:xpath, attribute_profile_path) }
-      let(:idp_sso_descriptor) do
-        create :idp_sso_descriptor, :with_attribute_profiles
-      end
-      it 'is rendered' do
-        expect(xml).to have_xpath(attribute_profile_path, count: 2)
-      end
-      it 'has expected value' do
-        expect(node.text).to eq(idp_sso_descriptor.attribute_profiles.first.uri)
-      end
+  context 'AttributeProfiles when populated' do
+    let(:node) { xml.first(:xpath, attribute_profile_path) }
+    let(:idp_sso_descriptor) do
+      create :idp_sso_descriptor, :with_attribute_profiles
+    end
+    it 'is rendered' do
+      expect(xml).to have_xpath(attribute_profile_path, count: 2)
+      expect(node.text).to eq(idp_sso_descriptor.attribute_profiles.first.uri)
     end
   end
 
-  context 'Attributes' do
-    context 'when populated' do
-      let(:idp_sso_descriptor) do
-        create :idp_sso_descriptor, :with_attributes
-      end
-      it 'is rendered' do
-        expect(xml).to have_xpath(attribute_path, count: 2)
-      end
+  context 'Attributes when populated' do
+    let(:idp_sso_descriptor) do
+      create :idp_sso_descriptor, :with_attributes
+    end
+    it 'is rendered' do
+      expect(xml).to have_xpath(attribute_path, count: 2)
     end
   end
 
-  context 'mdui:DiscoHints' do
-    context 'when populated' do
-      let(:idp_sso_descriptor) do
-        create :idp_sso_descriptor, :with_disco_hints
-      end
-      it 'is rendered' do
-        expect(xml).to have_xpath(mdui_disco_hints_path)
-      end
+  context 'mdui:DiscoHints when populated' do
+    let(:idp_sso_descriptor) do
+      create :idp_sso_descriptor, :with_disco_hints
+    end
+    it 'is rendered' do
+      expect(xml).to have_xpath(mdui_disco_hints_path)
     end
   end
 end

--- a/spec/support/metadata/key_descriptor.rb
+++ b/spec/support/metadata/key_descriptor.rb
@@ -5,7 +5,7 @@ RSpec.shared_examples 'KeyDescriptor xml' do
   let(:key_info_path) { "#{key_descriptor_path}/ds:KeyInfo" }
   let(:node) { xml.first(:xpath, key_descriptor_path) }
 
-  it 'is created' do
+  it 'is created, no use' do
     expect(xml).to have_xpath(key_descriptor_path)
     expect(xml).to have_xpath(key_info_path)
     expect(node['use']).to be_falsey

--- a/spec/support/metadata/key_descriptor.rb
+++ b/spec/support/metadata/key_descriptor.rb
@@ -3,19 +3,16 @@
 RSpec.shared_examples 'KeyDescriptor xml' do
   let(:key_descriptor_path) { '/KeyDescriptor' }
   let(:key_info_path) { "#{key_descriptor_path}/ds:KeyInfo" }
+  let(:node) { xml.first(:xpath, key_descriptor_path) }
 
   it 'is created' do
     expect(xml).to have_xpath(key_descriptor_path)
+    expect(xml).to have_xpath(key_info_path)
+    expect(node['use']).to be_falsey
   end
 
   context 'attributes' do
-    let(:node) { xml.first(:xpath, key_descriptor_path) }
     context 'use' do
-      context 'when not populated' do
-        it 'is not rendered' do
-          expect(node['use']).to be_falsey
-        end
-      end
       context 'when populated' do
         context 'for signing' do
           let(:key_descriptor) do
@@ -34,12 +31,6 @@ RSpec.shared_examples 'KeyDescriptor xml' do
           end
         end
       end
-    end
-  end
-
-  context 'KeyInfo' do
-    it 'is created' do
-      expect(xml).to have_xpath(key_info_path)
     end
   end
 end

--- a/spec/support/metadata/key_descriptor.rb
+++ b/spec/support/metadata/key_descriptor.rb
@@ -11,25 +11,21 @@ RSpec.shared_examples 'KeyDescriptor xml' do
     expect(node['use']).to be_falsey
   end
 
-  context 'attributes' do
-    context 'use' do
-      context 'when populated' do
-        context 'for signing' do
-          let(:key_descriptor) do
-            create(:key_descriptor, :signing)
-          end
-          it 'is rendered' do
-            expect(node['use']).to eq('signing')
-          end
-        end
-        context 'for encryption' do
-          let(:key_descriptor) do
-            create(:key_descriptor, :encryption)
-          end
-          it 'is rendered' do
-            expect(node['use']).to eq('encryption')
-          end
-        end
+  context 'attributes use when populated' do
+    context 'for signing' do
+      let(:key_descriptor) do
+        create(:key_descriptor, :signing)
+      end
+      it 'is rendered' do
+        expect(node['use']).to eq('signing')
+      end
+    end
+    context 'for encryption' do
+      let(:key_descriptor) do
+        create(:key_descriptor, :encryption)
+      end
+      it 'is rendered' do
+        expect(node['use']).to eq('encryption')
       end
     end
   end

--- a/spec/support/metadata/key_info.rb
+++ b/spec/support/metadata/key_info.rb
@@ -9,26 +9,18 @@ RSpec.shared_examples 'ds:KeyInfo xml' do
 
   it 'is created' do
     expect(xml).to have_xpath(key_info_path)
+    expect(xml).to have_xpath(x509_data_path)
+    expect(xml).not_to have_xpath(x509_subject_name_path)
   end
 
   context 'X509Data' do
-    it 'is created' do
-      expect(xml).to have_xpath(x509_data_path)
-    end
     context 'X509SubjectName' do
       context 'is set' do
         let(:key_info) { create :key_info, :with_subject }
         let(:node) { xml.find(:xpath, x509_subject_name_path) }
         it 'is created' do
           expect(xml).to have_xpath(x509_subject_name_path)
-        end
-        it 'has correct value' do
           expect(node.text).to eq(key_info.subject)
-        end
-      end
-      context 'is not set' do
-        it 'is not created' do
-          expect(xml).not_to have_xpath(x509_subject_name_path)
         end
       end
     end
@@ -36,8 +28,6 @@ RSpec.shared_examples 'ds:KeyInfo xml' do
       let(:node) { xml.find(:xpath, x509_certificate_path) }
       it 'is created' do
         expect(xml).to have_xpath(x509_certificate_path)
-      end
-      it 'has correct value' do
         expect(node.text).to eq(key_info.certificate_without_anchors)
       end
     end

--- a/spec/support/metadata/key_info.rb
+++ b/spec/support/metadata/key_info.rb
@@ -14,14 +14,12 @@ RSpec.shared_examples 'ds:KeyInfo xml' do
   end
 
   context 'X509Data' do
-    context 'X509SubjectName' do
-      context 'is set' do
-        let(:key_info) { create :key_info, :with_subject }
-        let(:node) { xml.find(:xpath, x509_subject_name_path) }
-        it 'is created' do
-          expect(xml).to have_xpath(x509_subject_name_path)
-          expect(node.text).to eq(key_info.subject)
-        end
+    context 'X509SubjectName is set' do
+      let(:key_info) { create :key_info, :with_subject }
+      let(:node) { xml.find(:xpath, x509_subject_name_path) }
+      it 'is created' do
+        expect(xml).to have_xpath(x509_subject_name_path)
+        expect(node.text).to eq(key_info.subject)
       end
     end
     context 'X509Certificate' do

--- a/spec/support/metadata/mdattr_entity_attribute.rb
+++ b/spec/support/metadata/mdattr_entity_attribute.rb
@@ -6,13 +6,10 @@ RSpec.shared_examples 'mdattr:EntityAttribute xml' do
 
   it 'is created' do
     expect(xml).to have_xpath(entity_attribute_path, count: 1)
+    expect(xml).to have_xpath(attribute_path, count: 1)
   end
 
   context 'attributes' do
-    it 'creates single attribute node' do
-      expect(xml).to have_xpath(attribute_path, count: 1)
-    end
-
     context 'multiple attributes' do
       let(:entity_attribute) do
         create :mdattr_entity_attribute, :with_multiple_attributes

--- a/spec/support/metadata/mdattr_entity_attribute.rb
+++ b/spec/support/metadata/mdattr_entity_attribute.rb
@@ -9,14 +9,12 @@ RSpec.shared_examples 'mdattr:EntityAttribute xml' do
     expect(xml).to have_xpath(attribute_path, count: 1)
   end
 
-  context 'attributes' do
-    context 'multiple attributes' do
-      let(:entity_attribute) do
-        create :mdattr_entity_attribute, :with_multiple_attributes
-      end
-      it 'creates attribute nodes' do
-        expect(xml).to have_xpath(attribute_path, count: 3)
-      end
+  context 'attributes multiple attributes' do
+    let(:entity_attribute) do
+      create :mdattr_entity_attribute, :with_multiple_attributes
+    end
+    it 'creates attribute nodes' do
+      expect(xml).to have_xpath(attribute_path, count: 3)
     end
   end
 

--- a/spec/support/metadata/mdrpi_publisher_info.rb
+++ b/spec/support/metadata/mdrpi_publisher_info.rb
@@ -8,26 +8,20 @@ RSpec.shared_examples 'mdrpi:PublisherInfo xml' do
     context 'PublisherInfo' do
       it 'is created' do
         expect(xml).to have_xpath(publication_info_path, count: 1)
+        expect(xml).to have_xpath(usage_policy_path, count: 1)
       end
       context 'attributes' do
         let(:node) { xml.find(:xpath, publication_info_path) }
         it 'sets publisher' do
           expect(node['publisher'])
             .to eq(root_node.publication_info.publisher)
-        end
-        it 'sets creationInstant' do
           expect(node['creationInstant'])
             .to eq(subject.created_at.xmlschema)
-        end
-        it 'sets publicationId' do
           expect(node['publicationId']).to eq(subject.instance_id)
             .and start_with(federation_identifier)
         end
       end
       context 'UsagePolicy' do
-        it 'is created' do
-          expect(xml).to have_xpath(usage_policy_path, count: 1)
-        end
         context 'attributes' do
           let(:node) { xml.first(:xpath, usage_policy_path) }
           it 'sets lang' do

--- a/spec/support/metadata/mdrpi_publisher_info.rb
+++ b/spec/support/metadata/mdrpi_publisher_info.rb
@@ -6,13 +6,13 @@ RSpec.shared_examples 'mdrpi:PublisherInfo xml' do
     let(:usage_policy_path) { "#{publication_info_path}/mdrpi:UsagePolicy" }
 
     context 'PublisherInfo' do
-      it 'is created' do
+      it 'is created, UsagePolicy' do
         expect(xml).to have_xpath(publication_info_path, count: 1)
         expect(xml).to have_xpath(usage_policy_path, count: 1)
       end
       context 'attributes' do
         let(:node) { xml.find(:xpath, publication_info_path) }
-        it 'sets publisher' do
+        it 'sets publisher, creationInstant, publicationId' do
           expect(node['publisher'])
             .to eq(root_node.publication_info.publisher)
           expect(node['creationInstant'])

--- a/spec/support/metadata/mdrpi_registration_info.rb
+++ b/spec/support/metadata/mdrpi_registration_info.rb
@@ -11,7 +11,7 @@ RSpec.shared_examples 'mdrpi:RegistrationInfo xml' do
       expect(xml).to have_xpath(registration_info_path, count: 1)
     end
 
-    context 'attributes' do
+    context 'attributes, registration instant, registrationAuthority' do
       let(:node) { xml.find(:xpath, registration_info_path) }
       it 'sets registration authority' do
         expect(node['registrationAuthority'])
@@ -27,7 +27,7 @@ RSpec.shared_examples 'mdrpi:RegistrationInfo xml' do
       let(:rp) do
         root_node.registration_info.registration_policies.first
       end
-      it 'is created' do
+      it 'is created with lang and text' do
         expect(xml).to have_xpath(registration_policies_path, count: 1)
         expect(node['xml:lang']).to eq(rp.lang)
         expect(node.text).to eq(rp.uri)

--- a/spec/support/metadata/mdrpi_registration_info.rb
+++ b/spec/support/metadata/mdrpi_registration_info.rb
@@ -29,7 +29,7 @@ RSpec.shared_examples 'mdrpi:RegistrationInfo xml' do
       end
       it 'is created' do
         expect(xml).to have_xpath(registration_policies_path, count: 1)
-          expect(node['xml:lang']).to eq(rp.lang)
+        expect(node['xml:lang']).to eq(rp.lang)
         expect(node.text).to eq(rp.uri)
       end
     end

--- a/spec/support/metadata/mdrpi_registration_info.rb
+++ b/spec/support/metadata/mdrpi_registration_info.rb
@@ -16,8 +16,6 @@ RSpec.shared_examples 'mdrpi:RegistrationInfo xml' do
       it 'sets registration authority' do
         expect(node['registrationAuthority'])
           .to eq(root_node.registration_info.registration_authority)
-      end
-      it 'sets registration instant' do
         expect(node['registrationInstant'])
           .to eq(root_node.registration_info
                    .registration_instant_utc.xmlschema)
@@ -31,13 +29,7 @@ RSpec.shared_examples 'mdrpi:RegistrationInfo xml' do
       end
       it 'is created' do
         expect(xml).to have_xpath(registration_policies_path, count: 1)
-      end
-      context 'attributes' do
-        it 'sets policy language' do
           expect(node['xml:lang']).to eq(rp.lang)
-        end
-      end
-      it 'sets policy value to policy URI' do
         expect(node.text).to eq(rp.uri)
       end
     end

--- a/spec/support/metadata/mdui_disco_hints.rb
+++ b/spec/support/metadata/mdui_disco_hints.rb
@@ -6,7 +6,7 @@ RSpec.shared_examples 'mdui:DiscoHints xml' do
   let(:domain_hint_path) { "#{mdui_disco_path}/mdui:DomainHint" }
   let(:geolocation_hint_path) { "#{mdui_disco_path}/mdui:GeolocationHint" }
 
-  it 'is created' do
+  it 'is created with IPHints and domain hints and geolocation hints and disco hints' do
     expect(xml).to have_xpath(mdui_disco_path, count: 1)
     expect(xml).to have_xpath(ip_hint_path, count: 1)
     expect(xml).to have_xpath(domain_hint_path, count: 1)

--- a/spec/support/metadata/mdui_disco_hints.rb
+++ b/spec/support/metadata/mdui_disco_hints.rb
@@ -8,13 +8,12 @@ RSpec.shared_examples 'mdui:DiscoHints xml' do
 
   it 'is created' do
     expect(xml).to have_xpath(mdui_disco_path, count: 1)
+    expect(xml).to have_xpath(ip_hint_path, count: 1)
+    expect(xml).to have_xpath(domain_hint_path, count: 1)
+    expect(xml).to have_xpath(geolocation_hint_path, count: 1)
   end
 
   context 'IPHints' do
-    it 'is created' do
-      expect(xml).to have_xpath(ip_hint_path, count: 1)
-    end
-
     context 'rendered node' do
       let(:node) { xml.first(:xpath, ip_hint_path) }
       it 'sets correct value' do
@@ -24,10 +23,6 @@ RSpec.shared_examples 'mdui:DiscoHints xml' do
   end
 
   context 'DomainHint' do
-    it 'is created' do
-      expect(xml).to have_xpath(domain_hint_path, count: 1)
-    end
-
     context 'rendered node' do
       let(:node) { xml.first(:xpath, domain_hint_path) }
       it 'sets correct value' do
@@ -37,10 +32,6 @@ RSpec.shared_examples 'mdui:DiscoHints xml' do
   end
 
   context 'GeolocationHint' do
-    it 'is created' do
-      expect(xml).to have_xpath(geolocation_hint_path, count: 1)
-    end
-
     context 'rendered node' do
       let(:node) { xml.first(:xpath, geolocation_hint_path) }
       it 'sets correct value' do

--- a/spec/support/metadata/mdui_disco_hints.rb
+++ b/spec/support/metadata/mdui_disco_hints.rb
@@ -13,30 +13,24 @@ RSpec.shared_examples 'mdui:DiscoHints xml' do
     expect(xml).to have_xpath(geolocation_hint_path, count: 1)
   end
 
-  context 'IPHints' do
-    context 'rendered node' do
-      let(:node) { xml.first(:xpath, ip_hint_path) }
-      it 'sets correct value' do
-        expect(node.text).to eq(disco_hints.ip_hints.first.block)
-      end
+  context 'IPHints rendered node' do
+    let(:node) { xml.first(:xpath, ip_hint_path) }
+    it 'sets correct value' do
+      expect(node.text).to eq(disco_hints.ip_hints.first.block)
     end
   end
 
-  context 'DomainHint' do
-    context 'rendered node' do
-      let(:node) { xml.first(:xpath, domain_hint_path) }
-      it 'sets correct value' do
-        expect(node.text).to eq(disco_hints.domain_hints.first.domain)
-      end
+  context 'DomainHint rendered node' do
+    let(:node) { xml.first(:xpath, domain_hint_path) }
+    it 'sets correct value' do
+      expect(node.text).to eq(disco_hints.domain_hints.first.domain)
     end
   end
 
-  context 'GeolocationHint' do
-    context 'rendered node' do
-      let(:node) { xml.first(:xpath, geolocation_hint_path) }
-      it 'sets correct value' do
-        expect(node.text).to eq(disco_hints.geolocation_hints.first.uri)
-      end
+  context 'GeolocationHint rendered node' do
+    let(:node) { xml.first(:xpath, geolocation_hint_path) }
+    it 'sets correct value' do
+      expect(node.text).to eq(disco_hints.geolocation_hints.first.uri)
     end
   end
 end

--- a/spec/support/metadata/mdui_ui_info.rb
+++ b/spec/support/metadata/mdui_ui_info.rb
@@ -13,19 +13,15 @@ RSpec.shared_examples 'mdui:UIInfo xml' do
 
   it 'is created' do
     expect(xml).to have_xpath(mdui_ui_info_path, count: 1)
+    expect(xml).to have_xpath(mdui_display_name_path, count: 1)
+    expect(xml).to have_xpath(mdui_description_path, count: 1)
   end
 
   context 'DisplayName' do
-    it 'is created' do
-      expect(xml).to have_xpath(mdui_display_name_path, count: 1)
-    end
-
     context 'rendered node' do
       let(:node) { xml.first(:xpath, mdui_display_name_path) }
       it 'sets language' do
         expect(node['xml:lang']).to eq(ui_info.display_names.first.lang)
-      end
-      it 'sets correct value' do
         expect(node.text).to eq(ui_info.display_names.first.value)
       end
     end
@@ -39,16 +35,10 @@ RSpec.shared_examples 'mdui:UIInfo xml' do
   end
 
   context 'Description' do
-    it 'is created' do
-      expect(xml).to have_xpath(mdui_description_path, count: 1)
-    end
-
     context 'rendered node' do
       let(:node) { xml.first(:xpath, mdui_description_path) }
       it 'sets language' do
         expect(node['xml:lang']).to eq(ui_info.descriptions.first.lang)
-      end
-      it 'sets correct value' do
         expect(node.text).to eq(ui_info.descriptions.first.value)
       end
     end
@@ -72,8 +62,6 @@ RSpec.shared_examples 'mdui:UIInfo xml' do
       let(:node) { xml.first(:xpath, mdui_keywords_path) }
       it 'sets language' do
         expect(node['xml:lang']).to eq(ui_info.keyword_lists.first.lang)
-      end
-      it 'sets correct value' do
         expect(node.text).to eq(ui_info.keyword_lists.first.content)
       end
     end
@@ -90,14 +78,8 @@ RSpec.shared_examples 'mdui:UIInfo xml' do
       let(:node) { xml.first(:xpath, mdui_logo_path) }
       it 'sets language' do
         expect(node['xml:lang']).to eq(ui_info.logos.first.lang)
-      end
-      it 'sets height' do
         expect(node['height']).to eq(ui_info.logos.first.height.to_s)
-      end
-      it 'sets width' do
         expect(node['width']).to eq(ui_info.logos.first.width.to_s)
-      end
-      it 'sets correct value' do
         expect(node.text).to eq(ui_info.logos.first.uri)
       end
     end
@@ -114,8 +96,6 @@ RSpec.shared_examples 'mdui:UIInfo xml' do
       let(:node) { xml.first(:xpath, mdui_informationurl_path) }
       it 'sets language' do
         expect(node['xml:lang']).to eq(ui_info.information_urls.first.lang)
-      end
-      it 'sets correct value' do
         expect(node.text).to eq(ui_info.information_urls.first.uri)
       end
     end
@@ -133,8 +113,6 @@ RSpec.shared_examples 'mdui:UIInfo xml' do
       it 'sets language' do
         expect(node['xml:lang'])
           .to eq(ui_info.privacy_statement_urls.first.lang)
-      end
-      it 'sets correct value' do
         expect(node.text).to eq(ui_info.privacy_statement_urls.first.uri)
       end
     end

--- a/spec/support/metadata/mdui_ui_info.rb
+++ b/spec/support/metadata/mdui_ui_info.rb
@@ -11,7 +11,7 @@ RSpec.shared_examples 'mdui:UIInfo xml' do
     "#{mdui_ui_info_path}/mdui:PrivacyStatementURL"
   end
 
-  it 'is created' do
+  it 'is created with ui info and display_name and description path' do
     expect(xml).to have_xpath(mdui_ui_info_path, count: 1)
     expect(xml).to have_xpath(mdui_display_name_path, count: 1)
     expect(xml).to have_xpath(mdui_description_path, count: 1)
@@ -20,7 +20,7 @@ RSpec.shared_examples 'mdui:UIInfo xml' do
   context 'DisplayName' do
     context 'rendered node' do
       let(:node) { xml.first(:xpath, mdui_display_name_path) }
-      it 'sets language' do
+      it 'sets languageand text' do
         expect(node['xml:lang']).to eq(ui_info.display_names.first.lang)
         expect(node.text).to eq(ui_info.display_names.first.value)
       end
@@ -37,7 +37,7 @@ RSpec.shared_examples 'mdui:UIInfo xml' do
   context 'Description' do
     context 'rendered node' do
       let(:node) { xml.first(:xpath, mdui_description_path) }
-      it 'sets language' do
+      it 'sets language and text' do
         expect(node['xml:lang']).to eq(ui_info.descriptions.first.lang)
         expect(node.text).to eq(ui_info.descriptions.first.value)
       end
@@ -60,7 +60,7 @@ RSpec.shared_examples 'mdui:UIInfo xml' do
 
     context 'rendered node' do
       let(:node) { xml.first(:xpath, mdui_keywords_path) }
-      it 'sets language' do
+      it 'sets language and text' do
         expect(node['xml:lang']).to eq(ui_info.keyword_lists.first.lang)
         expect(node.text).to eq(ui_info.keyword_lists.first.content)
       end
@@ -76,7 +76,7 @@ RSpec.shared_examples 'mdui:UIInfo xml' do
 
     context 'rendered node' do
       let(:node) { xml.first(:xpath, mdui_logo_path) }
-      it 'sets language' do
+      it 'sets language, height, width and text' do
         expect(node['xml:lang']).to eq(ui_info.logos.first.lang)
         expect(node['height']).to eq(ui_info.logos.first.height.to_s)
         expect(node['width']).to eq(ui_info.logos.first.width.to_s)
@@ -94,7 +94,7 @@ RSpec.shared_examples 'mdui:UIInfo xml' do
 
     context 'rendered node' do
       let(:node) { xml.first(:xpath, mdui_informationurl_path) }
-      it 'sets language' do
+      it 'sets language and text' do
         expect(node['xml:lang']).to eq(ui_info.information_urls.first.lang)
         expect(node.text).to eq(ui_info.information_urls.first.uri)
       end
@@ -110,7 +110,7 @@ RSpec.shared_examples 'mdui:UIInfo xml' do
 
     context 'rendered node' do
       let(:node) { xml.first(:xpath, mdui_privacystatementurl_path) }
-      it 'sets language' do
+      it 'sets language, text' do
         expect(node['xml:lang'])
           .to eq(ui_info.privacy_statement_urls.first.lang)
         expect(node.text).to eq(ui_info.privacy_statement_urls.first.uri)

--- a/spec/support/metadata/mdui_ui_info.rb
+++ b/spec/support/metadata/mdui_ui_info.rb
@@ -110,7 +110,7 @@ RSpec.shared_examples 'mdui:UIInfo xml' do
 
     context 'rendered node' do
       let(:node) { xml.first(:xpath, mdui_privacystatementurl_path) }
-      it 'sets language, text' do
+      it 'sets language and text' do
         expect(node['xml:lang'])
           .to eq(ui_info.privacy_statement_urls.first.lang)
         expect(node.text).to eq(ui_info.privacy_statement_urls.first.uri)

--- a/spec/support/metadata/mdui_ui_info.rb
+++ b/spec/support/metadata/mdui_ui_info.rb
@@ -20,7 +20,7 @@ RSpec.shared_examples 'mdui:UIInfo xml' do
   context 'DisplayName' do
     context 'rendered node' do
       let(:node) { xml.first(:xpath, mdui_display_name_path) }
-      it 'sets languageand text' do
+      it 'sets language and text' do
         expect(node['xml:lang']).to eq(ui_info.display_names.first.lang)
         expect(node.text).to eq(ui_info.display_names.first.value)
       end

--- a/spec/support/metadata/organization.rb
+++ b/spec/support/metadata/organization.rb
@@ -15,7 +15,7 @@ RSpec.shared_examples 'Organization xml' do
   context 'OrganizationName' do
     let(:node) { xml.first(:xpath, organization_name_path) }
 
-    it 'is created' do
+    it 'is created, lang and text' do
       expect(xml).to have_xpath(organization_name_path, count: 2)
       expect(node['xml:lang'])
         .to eq(organization.organization_names.first.lang)
@@ -26,7 +26,7 @@ RSpec.shared_examples 'Organization xml' do
   context 'OrganizationDisplayName' do
     let(:node) { xml.first(:xpath, organization_display_name_path) }
 
-    it 'is created' do
+    it 'is created, lang and value' do
       expect(xml).to have_xpath(organization_display_name_path, count: 2)
       expect(node['xml:lang'])
         .to eq(organization.organization_display_names.first.lang)
@@ -38,7 +38,7 @@ RSpec.shared_examples 'Organization xml' do
   context 'OrganizationURL' do
     let(:node) { xml.first(:xpath, organization_url_path) }
 
-    it 'is created' do
+    it 'is created, lang and uri' do
       expect(xml).to have_xpath(organization_url_path, count: 2)
       expect(node['xml:lang'])
         .to eq(organization.organization_urls.first.lang)

--- a/spec/support/metadata/organization.rb
+++ b/spec/support/metadata/organization.rb
@@ -17,16 +17,8 @@ RSpec.shared_examples 'Organization xml' do
 
     it 'is created' do
       expect(xml).to have_xpath(organization_name_path, count: 2)
-    end
-
-    context 'attributes' do
-      it 'sets lang' do
-        expect(node['xml:lang'])
-          .to eq(organization.organization_names.first.lang)
-      end
-    end
-
-    it 'has correct value' do
+      expect(node['xml:lang'])
+        .to eq(organization.organization_names.first.lang)
       expect(node.text).to eq(organization.organization_names.first.value)
     end
   end
@@ -36,16 +28,8 @@ RSpec.shared_examples 'Organization xml' do
 
     it 'is created' do
       expect(xml).to have_xpath(organization_display_name_path, count: 2)
-    end
-
-    context 'attributes' do
-      it 'sets lang' do
-        expect(node['xml:lang'])
-          .to eq(organization.organization_display_names.first.lang)
-      end
-    end
-
-    it 'has correct value' do
+      expect(node['xml:lang'])
+        .to eq(organization.organization_display_names.first.lang)
       expect(node.text)
         .to eq(organization.organization_display_names.first.value)
     end
@@ -56,16 +40,8 @@ RSpec.shared_examples 'Organization xml' do
 
     it 'is created' do
       expect(xml).to have_xpath(organization_url_path, count: 2)
-    end
-
-    context 'attributes' do
-      it 'sets lang' do
-        expect(node['xml:lang'])
-          .to eq(organization.organization_urls.first.lang)
-      end
-    end
-
-    it 'has correct value' do
+      expect(node['xml:lang'])
+        .to eq(organization.organization_urls.first.lang)
       expect(node.text)
         .to eq(organization.organization_urls.first.uri)
     end

--- a/spec/support/metadata/raw_entity_descriptor.rb
+++ b/spec/support/metadata/raw_entity_descriptor.rb
@@ -27,7 +27,7 @@ RSpec.shared_examples 'RawEntityDescriptor xml' do
 
     around { |example| Timecop.freeze { example.run } }
 
-    it 'sets ID' do
+    it 'sets ID and validUntil' do
       expect(node['ID']).to eq(subject.instance_id)
         .and start_with(federation_identifier)
       expect(node['validUntil'])

--- a/spec/support/metadata/raw_entity_descriptor.rb
+++ b/spec/support/metadata/raw_entity_descriptor.rb
@@ -20,20 +20,18 @@ RSpec.shared_examples 'RawEntityDescriptor xml' do
   let(:entity_source) { known_entity.entity_source }
   let(:entity_descriptor_path) { '/EntityDescriptor' }
 
-  context 'Root EntityDescriptor' do
+  context 'Root EntityDescriptor attributes' do
     before { subject.root_entity_descriptor(known_entity) }
 
-    context 'attributes' do
-      let(:node) { xml.find(:xpath, entity_descriptor_path) }
+    let(:node) { xml.find(:xpath, entity_descriptor_path) }
 
-      around { |example| Timecop.freeze { example.run } }
+    around { |example| Timecop.freeze { example.run } }
 
-      it 'sets ID' do
-        expect(node['ID']).to eq(subject.instance_id)
-          .and start_with(federation_identifier)
-        expect(node['validUntil'])
-          .to eq((Time.now.utc + metadata_validity_period).xmlschema)
-      end
+    it 'sets ID' do
+      expect(node['ID']).to eq(subject.instance_id)
+        .and start_with(federation_identifier)
+      expect(node['validUntil'])
+        .to eq((Time.now.utc + metadata_validity_period).xmlschema)
     end
   end
 

--- a/spec/support/metadata/raw_entity_descriptor.rb
+++ b/spec/support/metadata/raw_entity_descriptor.rb
@@ -31,8 +31,6 @@ RSpec.shared_examples 'RawEntityDescriptor xml' do
       it 'sets ID' do
         expect(node['ID']).to eq(subject.instance_id)
           .and start_with(federation_identifier)
-      end
-      it 'sets validUntil' do
         expect(node['validUntil'])
           .to eq((Time.now.utc + metadata_validity_period).xmlschema)
       end

--- a/spec/support/metadata/requested_attribute.rb
+++ b/spec/support/metadata/requested_attribute.rb
@@ -16,15 +16,13 @@ RSpec.shared_examples 'RequestedAttribute xml' do
 
   context 'RequestedAttribute' do
     context 'attributes' do
-      context 'NameFormat' do
-        context 'with value' do
-          let(:requested_attribute) do
-            create :requested_attribute, :with_name_format
-          end
-          it 'is included' do
-            expect(node['NameFormat'])
-              .to eq(requested_attribute.name_format.uri)
-          end
+      context 'NameFormat with value' do
+        let(:requested_attribute) do
+          create :requested_attribute, :with_name_format
+        end
+        it 'is included' do
+          expect(node['NameFormat'])
+            .to eq(requested_attribute.name_format.uri)
         end
       end
 

--- a/spec/support/metadata/requested_attribute.rb
+++ b/spec/support/metadata/requested_attribute.rb
@@ -3,6 +3,9 @@
 RSpec.shared_examples 'RequestedAttribute xml' do
   it 'is created' do
     expect(xml).to have_xpath(requested_attribute_path)
+    expect(xml).to have_xpath(requested_attribute_path, count: 1)
+    expect(node['Name']).to eq(requested_attribute.name)
+    expect(node['NameFormat']).to be_falsey
   end
 
   let(:attribute_value_path) do
@@ -12,21 +15,8 @@ RSpec.shared_examples 'RequestedAttribute xml' do
   let(:node) { xml.find(:xpath, requested_attribute_path) }
 
   context 'RequestedAttribute' do
-    it 'is created' do
-      expect(xml).to have_xpath(requested_attribute_path, count: 1)
-    end
-
     context 'attributes' do
-      it 'sets Name' do
-        expect(node['Name']).to eq(requested_attribute.name)
-      end
-
       context 'NameFormat' do
-        context 'without value' do
-          it 'is not included' do
-            expect(node['NameFormat']).to be_falsey
-          end
-        end
         context 'with value' do
           let(:requested_attribute) do
             create :requested_attribute, :with_name_format
@@ -60,8 +50,6 @@ RSpec.shared_examples 'RequestedAttribute xml' do
         let(:requested_attribute) { create :requested_attribute, :is_required }
         it 'is rendered' do
           expect(node['isRequired']).to be_truthy
-        end
-        it 'has correct value' do
           expect(node['isRequired']).to eq(requested_attribute.required.to_s)
         end
       end
@@ -79,9 +67,6 @@ RSpec.shared_examples 'RequestedAttribute xml' do
         let(:requested_attribute) { create :requested_attribute, :with_values }
         it 'is created' do
           expect(xml).to have_xpath(attribute_value_path, count: 3)
-        end
-
-        it 'renders expected values' do
           nodes.each_with_index do |node, i|
             expect(node.text)
               .to eq(requested_attribute.attribute_values[i].value)

--- a/spec/support/metadata/role_descriptor.rb
+++ b/spec/support/metadata/role_descriptor.rb
@@ -11,7 +11,7 @@ RSpec.shared_examples 'RoleDescriptor xml' do
 
   let(:node) { xml.first(:xpath, role_descriptor_path) }
 
-  it 'is created' do
+  it 'is created without extensions, key_descriptiors, organizations, contacts, ui_info, shibmd, error url with protocols' do
     expect(xml).to have_xpath(role_descriptor_path)
     expect(role_descriptor.protocol_supports.length).to eq(2)
     expect(node['protocolSupportEnumeration'])

--- a/spec/support/metadata/role_descriptor.rb
+++ b/spec/support/metadata/role_descriptor.rb
@@ -25,76 +25,64 @@ RSpec.shared_examples 'RoleDescriptor xml' do
     expect(xml).not_to have_xpath(shibmd_scope_path)
   end
 
-  context 'attributes' do
-    context 'when populated' do
-      let(:role_descriptor) do
-        create parent_node, :with_error_url
-      end
-      it 'is rendered' do
-        expect(node['errorURL']).to eq(role_descriptor.error_url)
-      end
+  context 'attributes when populated' do
+    let(:role_descriptor) do
+      create parent_node, :with_error_url
+    end
+    it 'is rendered' do
+      expect(node['errorURL']).to eq(role_descriptor.error_url)
     end
   end
 
-  context 'Extensions' do
-    context 'when populated' do
-      let(:node) { xml.first(:xpath, extensions_path) }
-      let(:role_descriptor) do
-        create parent_node, :with_extensions
-      end
-      it 'is rendered' do
-        expect(node).to have_xpath(test_extensions_path)
-      end
+  context 'Extensions when populated' do
+    let(:node) { xml.first(:xpath, extensions_path) }
+    let(:role_descriptor) do
+      create parent_node, :with_extensions
+    end
+    it 'is rendered' do
+      expect(node).to have_xpath(test_extensions_path)
     end
   end
 
-  context 'KeyDescriptors' do
-    context 'when populated' do
-      let(:role_descriptor) { create parent_node, :with_key_descriptors }
-      it 'is rendered' do
+  context 'KeyDescriptors when populated' do
+    let(:role_descriptor) { create parent_node, :with_key_descriptors }
+    it 'is rendered' do
+      expect(xml).to have_xpath(key_descriptors_path, count: 2)
+    end
+
+    context 'with disabled keys' do
+      let(:role_descriptor) do
+        create parent_node, :with_key_descriptors,
+               :with_disabled_key_descriptor
+      end
+
+      it 'has 3 key_descriptors' do
+        expect(role_descriptor.key_descriptors.count).to eq(3)
+        disabled_kd = role_descriptor.key_descriptors.find_all(&:disabled)
+        expect(disabled_kd.count).to eq(1)
         expect(xml).to have_xpath(key_descriptors_path, count: 2)
       end
-
-      context 'with disabled keys' do
-        let(:role_descriptor) do
-          create parent_node, :with_key_descriptors,
-                 :with_disabled_key_descriptor
-        end
-
-        it 'has 3 key_descriptors' do
-          expect(role_descriptor.key_descriptors.count).to eq(3)
-          disabled_kd = role_descriptor.key_descriptors.find_all(&:disabled)
-          expect(disabled_kd.count).to eq(1)
-          expect(xml).to have_xpath(key_descriptors_path, count: 2)
-        end
-      end
     end
   end
 
-  context 'Contacts' do
-    context 'when populated' do
-      let(:role_descriptor) { create parent_node, :with_contacts }
-      it 'is rendered when present' do
-        expect(xml).to have_xpath(contacts_path, count: 2)
-      end
+  context 'Contacts when populated' do
+    let(:role_descriptor) { create parent_node, :with_contacts }
+    it 'is rendered when present' do
+      expect(xml).to have_xpath(contacts_path, count: 2)
     end
   end
 
-  context 'mdui:UIInfo' do
-    context 'when populated' do
-      let(:role_descriptor) { create parent_node, :with_ui_info }
-      it 'is rendered' do
-        expect(xml).to have_xpath(mdui_ui_info_path)
-      end
+  context 'mdui:UIInfo when populated' do
+    let(:role_descriptor) { create parent_node, :with_ui_info }
+    it 'is rendered' do
+      expect(xml).to have_xpath(mdui_ui_info_path)
     end
   end
 
-  context 'shibmd:Scope' do
-    context 'when populated' do
-      let(:role_descriptor) { create parent_node, :with_scopes }
-      it 'is rendered' do
-        expect(xml).to have_xpath(shibmd_scope_path, count: 2)
-      end
+  context 'shibmd:Scope when populated' do
+    let(:role_descriptor) { create parent_node, :with_scopes }
+    it 'is rendered' do
+      expect(xml).to have_xpath(shibmd_scope_path, count: 2)
     end
   end
 end

--- a/spec/support/metadata/role_descriptor.rb
+++ b/spec/support/metadata/role_descriptor.rb
@@ -13,22 +13,20 @@ RSpec.shared_examples 'RoleDescriptor xml' do
 
   it 'is created' do
     expect(xml).to have_xpath(role_descriptor_path)
+    expect(role_descriptor.protocol_supports.length).to eq(2)
+    expect(node['protocolSupportEnumeration'])
+      .to eq(role_descriptor.protocol_supports.map(&:uri).join(' '))
+      expect(node['errorURL']).to be_falsey
+      expect(xml).not_to have_xpath(extensions_path)
+      expect(xml).not_to have_xpath(key_descriptors_path)
+      expect(xml).not_to have_xpath(organization_path)
+      expect(xml).not_to have_xpath(contacts_path)
+      expect(xml).not_to have_xpath(mdui_ui_info_path)
+      expect(xml).not_to have_xpath(shibmd_scope_path)
+
   end
 
   context 'attributes' do
-    context 'protocol supports' do
-      it 'is rendered' do
-        expect(role_descriptor.protocol_supports.length).to eq(2)
-        expect(node['protocolSupportEnumeration'])
-          .to eq(role_descriptor.protocol_supports.map(&:uri).join(' '))
-      end
-    end
-    context 'error URL' do
-      context 'when not populated' do
-        it 'is not rendered' do
-          expect(node['errorURL']).to be_falsey
-        end
-      end
       context 'when populated' do
         let(:role_descriptor) do
           create parent_node, :with_error_url
@@ -37,15 +35,9 @@ RSpec.shared_examples 'RoleDescriptor xml' do
           expect(node['errorURL']).to eq(role_descriptor.error_url)
         end
       end
-    end
   end
 
   context 'Extensions' do
-    context 'when not populated' do
-      it 'is not rendered' do
-        expect(xml).not_to have_xpath(extensions_path)
-      end
-    end
     context 'when populated' do
       let(:node) { xml.first(:xpath, extensions_path) }
       let(:role_descriptor) do
@@ -72,28 +64,11 @@ RSpec.shared_examples 'RoleDescriptor xml' do
 
         it 'has 3 key_descriptors' do
           expect(role_descriptor.key_descriptors.count).to eq(3)
-        end
-
-        it 'has a disabled key_descriptor' do
           disabled_kd = role_descriptor.key_descriptors.find_all(&:disabled)
           expect(disabled_kd.count).to eq(1)
-        end
-
-        it 'is rendered' do
           expect(xml).to have_xpath(key_descriptors_path, count: 2)
         end
       end
-    end
-    context 'when not populated' do
-      it 'is not rendered' do
-        expect(xml).not_to have_xpath(key_descriptors_path)
-      end
-    end
-  end
-
-  context 'Organization' do
-    it 'is not rendered' do
-      expect(xml).not_to have_xpath(organization_path)
     end
   end
 
@@ -104,19 +79,9 @@ RSpec.shared_examples 'RoleDescriptor xml' do
         expect(xml).to have_xpath(contacts_path, count: 2)
       end
     end
-    context 'when not populated' do
-      it 'is not rendered' do
-        expect(xml).not_to have_xpath(contacts_path)
-      end
-    end
   end
 
   context 'mdui:UIInfo' do
-    context 'when not populated' do
-      it 'is not rendered' do
-        expect(xml).not_to have_xpath(mdui_ui_info_path)
-      end
-    end
     context 'when populated' do
       let(:role_descriptor) { create parent_node, :with_ui_info }
       it 'is rendered' do
@@ -126,11 +91,6 @@ RSpec.shared_examples 'RoleDescriptor xml' do
   end
 
   context 'shibmd:Scope' do
-    context 'when not populated' do
-      it 'is not rendered' do
-        expect(xml).not_to have_xpath(shibmd_scope_path)
-      end
-    end
     context 'when populated' do
       let(:role_descriptor) { create parent_node, :with_scopes }
       it 'is rendered' do

--- a/spec/support/metadata/role_descriptor.rb
+++ b/spec/support/metadata/role_descriptor.rb
@@ -16,25 +16,24 @@ RSpec.shared_examples 'RoleDescriptor xml' do
     expect(role_descriptor.protocol_supports.length).to eq(2)
     expect(node['protocolSupportEnumeration'])
       .to eq(role_descriptor.protocol_supports.map(&:uri).join(' '))
-      expect(node['errorURL']).to be_falsey
-      expect(xml).not_to have_xpath(extensions_path)
-      expect(xml).not_to have_xpath(key_descriptors_path)
-      expect(xml).not_to have_xpath(organization_path)
-      expect(xml).not_to have_xpath(contacts_path)
-      expect(xml).not_to have_xpath(mdui_ui_info_path)
-      expect(xml).not_to have_xpath(shibmd_scope_path)
-
+    expect(node['errorURL']).to be_falsey
+    expect(xml).not_to have_xpath(extensions_path)
+    expect(xml).not_to have_xpath(key_descriptors_path)
+    expect(xml).not_to have_xpath(organization_path)
+    expect(xml).not_to have_xpath(contacts_path)
+    expect(xml).not_to have_xpath(mdui_ui_info_path)
+    expect(xml).not_to have_xpath(shibmd_scope_path)
   end
 
   context 'attributes' do
-      context 'when populated' do
-        let(:role_descriptor) do
-          create parent_node, :with_error_url
-        end
-        it 'is rendered' do
-          expect(node['errorURL']).to eq(role_descriptor.error_url)
-        end
+    context 'when populated' do
+      let(:role_descriptor) do
+        create parent_node, :with_error_url
       end
+      it 'is rendered' do
+        expect(node['errorURL']).to eq(role_descriptor.error_url)
+      end
+    end
   end
 
   context 'Extensions' do

--- a/spec/support/metadata/role_descriptor.rb
+++ b/spec/support/metadata/role_descriptor.rb
@@ -11,7 +11,8 @@ RSpec.shared_examples 'RoleDescriptor xml' do
 
   let(:node) { xml.first(:xpath, role_descriptor_path) }
 
-  it 'is created without extensions, key_descriptiors, organizations, contacts, ui_info, shibmd, error url with protocols' do
+  it 'is created without extensions, key_descriptiors, organizations, contacts,' \
+     'ui_info, shibmd, error url with protocols' do
     expect(xml).to have_xpath(role_descriptor_path)
     expect(role_descriptor.protocol_supports.length).to eq(2)
     expect(node['protocolSupportEnumeration'])

--- a/spec/support/metadata/saml_namespaces.rb
+++ b/spec/support/metadata/saml_namespaces.rb
@@ -6,7 +6,7 @@ RSpec.shared_examples 'SAML namespaces' do
   context 'SAML namespaces' do
     let(:ns) { subject.ns }
 
-    it do
+    it 'works as expected' do
       is_expected.to be_a_kind_of Metadata::SamlNamespaces
       is_expected.to respond_to(:root).and(
         respond_to(:saml)

--- a/spec/support/metadata/saml_namespaces.rb
+++ b/spec/support/metadata/saml_namespaces.rb
@@ -7,9 +7,8 @@ RSpec.shared_examples 'SAML namespaces' do
     let(:ns) { subject.ns }
 
     it do
-      is_expected.to be_a_kind_of Metadata::SamlNamespaces.and(
-        respond_to(:root)
-      ).and(
+      is_expected.to be_a_kind_of Metadata::SamlNamespaces
+      is_expected.to respond_to(:root).and(
         respond_to(:saml)
       ).and(
         respond_to(:idpdisc)

--- a/spec/support/metadata/saml_namespaces.rb
+++ b/spec/support/metadata/saml_namespaces.rb
@@ -44,7 +44,8 @@ RSpec.shared_examples 'SAML namespaces' do
                             'xmlns:ds' => 'http://www.w3.org/2000/09/xmldsig#',
                             'xmlns:fed' => 'http://docs.oasis-open.org/wsfed/federation/200706',
                             'xmlns:privacy' => 'http://docs.oasis-open.org/wsfed/privacy/200706',
-                            'xmlns:remd' => 'http://refeds.org/metadata'
+                            'xmlns:remd' => 'http://refeds.org/metadata',
+                            'xmlns:xsi' => 'http://www.w3.org/2001/XMLSchema-instance'
                           })
     end
   end

--- a/spec/support/metadata/saml_namespaces.rb
+++ b/spec/support/metadata/saml_namespaces.rb
@@ -4,71 +4,49 @@ require 'rails_helper'
 
 RSpec.shared_examples 'SAML namespaces' do
   context 'SAML namespaces' do
-    it { is_expected.to be_a_kind_of Metadata::SamlNamespaces }
+    let(:ns) { subject.ns }
 
-    it { is_expected.to respond_to(:root) }
-    it { is_expected.to respond_to(:saml) }
-    it { is_expected.to respond_to(:idpdisc) }
-    it { is_expected.to respond_to(:mdrpi) }
-    it { is_expected.to respond_to(:mdui) }
-    it { is_expected.to respond_to(:mdattr) }
-    it { is_expected.to respond_to(:shibmd) }
-    it { is_expected.to respond_to(:ds) }
-    it { is_expected.to respond_to(:ns) }
-
-    it {
-      is_expected.to respond_to(:fed)
+    it do
+      is_expected.to be_a_kind_of Metadata::SamlNamespaces.and(
+        respond_to(:root)
+      ).and(
+        respond_to(:saml)
+      ).and(
+        respond_to(:idpdisc)
+      ).and(
+        respond_to(:mdrpi)
+      ).and(
+        respond_to(:mdui)
+      ).and(
+        respond_to(:mdattr)
+      ).and(
+        respond_to(:shibmd)
+      ).and(
+        respond_to(:ds)
+      ).and(
+        respond_to(:ns)
+      ).and(
+        respond_to(:fed)
+      ).and(
+        respond_to(:privacy)
+      )
       subject.fed
-    }
-
-    it {
-      is_expected.to respond_to(:privacy)
       subject.privacy
-    }
-
-    it 'has 12 namespaces defined' do
       expect(subject.ns.size).to eq(12)
       expect(Metadata::SamlNamespaces::NAMESPACES.size).to eq(12)
-    end
-
-    let(:ns) { subject.ns }
-    it 'supports SAML 2.0 metadata' do
-      expect(ns['xmlns']).to eq('urn:oasis:names:tc:SAML:2.0:metadata')
-    end
-    it 'supports SAML 2.0 assertion' do
-      expect(ns['xmlns:saml']).to eq('urn:oasis:names:tc:SAML:2.0:assertion')
-    end
-    it 'supports SAML SSO IdP discovery profile' do
-      expect(ns['xmlns:idpdisc'])
-        .to eq('urn:oasis:names:tc:SAML:profiles:SSO:idp-discovery-protocol')
-    end
-    it 'supports SAML Metadata RPI' do
-      expect(ns['xmlns:mdrpi']).to eq('urn:oasis:names:tc:SAML:metadata:rpi')
-    end
-    it 'supports SAML Metadata UI' do
-      expect(ns['xmlns:mdui']).to eq('urn:oasis:names:tc:SAML:metadata:ui')
-    end
-    it 'supports SAML Metadata Attributes' do
-      expect(ns['xmlns:mdattr'])
-        .to eq('urn:oasis:names:tc:SAML:metadata:attribute')
-    end
-    it 'supports Shibboleth 1.0 Metadata' do
-      expect(ns['xmlns:shibmd']).to eq('urn:mace:shibboleth:metadata:1.0')
-    end
-    it 'supports XML DSig' do
-      expect(ns['xmlns:ds']).to eq('http://www.w3.org/2000/09/xmldsig#')
-    end
-    it 'supports SAML 2.0 assertion' do
-      expect(ns['xmlns:saml']).to eq('urn:oasis:names:tc:SAML:2.0:assertion')
-    end
-    it 'supports SAML 2.0 assertion' do
-      expect(ns['xmlns:fed']).to eq('http://docs.oasis-open.org/wsfed/federation/200706')
-    end
-    it 'supports SAML 2.0 assertion' do
-      expect(ns['xmlns:privacy']).to eq('http://docs.oasis-open.org/wsfed/privacy/200706')
-    end
-    it 'supports REFEDS metadata extension schema' do
-      expect(ns['xmlns:remd']).to eq('http://refeds.org/metadata')
+      expect(ns).to match({
+                            'xmlns' => 'urn:oasis:names:tc:SAML:2.0:metadata',
+                            'xmlns:saml' => 'urn:oasis:names:tc:SAML:2.0:assertion',
+                            'xmlns:idpdisc' => 'urn:oasis:names:tc:SAML:profiles:SSO:idp-discovery-protocol',
+                            'xmlns:mdrpi' => 'urn:oasis:names:tc:SAML:metadata:rpi',
+                            'xmlns:mdui' => 'urn:oasis:names:tc:SAML:metadata:ui',
+                            'xmlns:mdattr' => 'urn:oasis:names:tc:SAML:metadata:attribute',
+                            'xmlns:shibmd' => 'urn:mace:shibboleth:metadata:1.0',
+                            'xmlns:ds' => 'http://www.w3.org/2000/09/xmldsig#',
+                            'xmlns:fed' => 'http://docs.oasis-open.org/wsfed/federation/200706',
+                            'xmlns:privacy' => 'http://docs.oasis-open.org/wsfed/privacy/200706',
+                            'xmlns:remd' => 'http://refeds.org/metadata'
+                          })
     end
   end
 end

--- a/spec/support/metadata/shibmd_key_authority.rb
+++ b/spec/support/metadata/shibmd_key_authority.rb
@@ -1,33 +1,29 @@
 # frozen_string_literal: true
 
 RSpec.shared_examples 'shibmd:KeyAuthority xml' do
-  context 'CA keys' do
+  context 'CA keys without CA keys' do
     let(:key_authority_path) { "#{extensions_path}/shibmd:KeyAuthority" }
     let(:key_info_path) { "#{key_authority_path}/ds:KeyInfo" }
 
-    context 'without CA keys' do
-      it 'does not populate KeyAuthority node' do
-        expect(xml).not_to have_xpath(key_authority_path)
-      end
+    it 'does not populate KeyAuthority node' do
+      expect(xml).not_to have_xpath(key_authority_path)
     end
 
-    context 'with CA keys' do
+    context 'with CA keys KeyAuthority' do
       let(:add_ca_keys) { true }
-      context 'KeyAuthority' do
-        it 'is created' do
-          expect(xml).to have_xpath(key_authority_path)
+      it 'is created' do
+        expect(xml).to have_xpath(key_authority_path)
+      end
+      context 'attributes' do
+        let(:node) { xml.find(:xpath, key_authority_path) }
+        it 'sets VerifyDepth' do
+          expect(node['VerifyDepth'])
+            .to eq(metadata_instance.ca_verify_depth.to_s)
         end
-        context 'attributes' do
-          let(:node) { xml.find(:xpath, key_authority_path) }
-          it 'sets VerifyDepth' do
-            expect(node['VerifyDepth'])
-              .to eq(metadata_instance.ca_verify_depth.to_s)
-          end
-        end
-        context 'KeyInfo' do
-          it 'creates two instances' do
-            expect(xml).to have_xpath(key_info_path, count: 2)
-          end
+      end
+      context 'KeyInfo' do
+        it 'creates two instances' do
+          expect(xml).to have_xpath(key_info_path, count: 2)
         end
       end
     end

--- a/spec/support/metadata/shibmd_scope.rb
+++ b/spec/support/metadata/shibmd_scope.rb
@@ -14,12 +14,10 @@ RSpec.shared_examples 'shibmd:Scope xml' do
       expect(node[:regexp]).to eq('false')
     end
 
-    context 'regexp' do
-      context 'with' do
-        let(:regexp) { true }
-        it 'is true' do
-          expect(node[:regexp]).to eq('true')
-        end
+    context 'regexp with' do
+      let(:regexp) { true }
+      it 'is true' do
+        expect(node[:regexp]).to eq('true')
       end
     end
   end

--- a/spec/support/metadata/shibmd_scope.rb
+++ b/spec/support/metadata/shibmd_scope.rb
@@ -11,14 +11,10 @@ RSpec.shared_examples 'shibmd:Scope xml' do
   context 'shibmd:Scope' do
     it 'sets node value' do
       expect(node.text).to eq(scope.value)
+      expect(node[:regexp]).to eq('false')
     end
 
     context 'regexp' do
-      context 'without' do
-        it 'is false' do
-          expect(node[:regexp]).to eq('false')
-        end
-      end
       context 'with' do
         let(:regexp) { true }
         it 'is true' do

--- a/spec/support/metadata/signature.rb
+++ b/spec/support/metadata/signature.rb
@@ -93,23 +93,27 @@ RSpec.shared_examples 'ds:Signature xml' do
         e = signed_info.find(:xpath, 'ds:SignatureMethod')
         expect(e['Algorithm'])
           .to eq('http://www.w3.org/2000/09/xmldsig#rsa-sha1')
+      end
 
+      it 'specifies the digest algorithm' do
         e = reference.find(:xpath, 'ds:DigestMethod')
         expect(e['Algorithm']).to eq('http://www.w3.org/2000/09/xmldsig#sha1')
-
-        rsa_sig = key.sign(OpenSSL::Digest.new('SHA1'), c14n_signed_info)
-        expected = Base64.strict_encode64(rsa_sig).strip
-
-        expect(signature.find(:xpath, 'ds:SignatureValue').text.strip)
-          .to eq(expected)
-
-        expect(validation_errors).to be_empty
       end
 
       it 'includes the digest value' do
-        hash = OpenSSL::Digest::SHA256.digest(c14n_xml)
+        hash = OpenSSL::Digest::SHA1.digest(c14n_xml)
         expect(reference.find(:xpath, 'ds:DigestValue').text.strip)
           .to eq(Base64.strict_encode64(hash))
+      end
+
+      it 'includes the signature value' do
+        rsa_sig = key.sign(OpenSSL::Digest.new('SHA1'), c14n_signed_info)
+        expect(signature.find(:xpath, 'ds:SignatureValue').text.strip)
+          .to eq(Base64.strict_encode64(rsa_sig).strip)
+      end
+
+      it 'is schema-valid' do
+        expect(validation_errors).to be_empty
       end
     end
 
@@ -120,21 +124,27 @@ RSpec.shared_examples 'ds:Signature xml' do
         e = signed_info.find(:xpath, 'ds:SignatureMethod')
         expect(e['Algorithm'])
           .to eq('http://www.w3.org/2001/04/xmldsig-more#rsa-sha256')
+      end
 
+      it 'specifies the digest algorithm' do
         e = reference.find(:xpath, 'ds:DigestMethod')
         expect(e['Algorithm']).to eq('http://www.w3.org/2001/04/xmlenc#sha256')
-
-        rsa_sig = key.sign(OpenSSL::Digest.new('SHA256'), c14n_signed_info)
-        expect(signature.find(:xpath, 'ds:SignatureValue').text.strip)
-          .to eq(Base64.strict_encode64(rsa_sig).strip)
-
-        expect(validation_errors).to be_empty
       end
 
       it 'includes the digest value' do
         hash = OpenSSL::Digest::SHA256.digest(c14n_xml)
         expect(reference.find(:xpath, 'ds:DigestValue').text.strip)
           .to eq(Base64.strict_encode64(hash))
+      end
+
+      it 'includes the signature value' do
+        rsa_sig = key.sign(OpenSSL::Digest.new('SHA256'), c14n_signed_info)
+        expect(signature.find(:xpath, 'ds:SignatureValue').text.strip)
+          .to eq(Base64.strict_encode64(rsa_sig).strip)
+      end
+
+      it 'is schema-valid' do
+        expect(validation_errors).to be_empty
       end
     end
   end

--- a/spec/support/metadata/signature.rb
+++ b/spec/support/metadata/signature.rb
@@ -97,12 +97,6 @@ RSpec.shared_examples 'ds:Signature xml' do
         e = reference.find(:xpath, 'ds:DigestMethod')
         expect(e['Algorithm']).to eq('http://www.w3.org/2000/09/xmldsig#sha1')
 
-        hash = OpenSSL::Digest::SHA1.digest(c14n_xml)
-        expected = Base64.strict_encode64(hash)
-
-        expect(reference.find(:xpath, 'ds:DigestValue').text.strip)
-          .to eq(expected)
-
         rsa_sig = key.sign(OpenSSL::Digest.new('SHA1'), c14n_signed_info)
         expected = Base64.strict_encode64(rsa_sig).strip
 
@@ -110,6 +104,12 @@ RSpec.shared_examples 'ds:Signature xml' do
           .to eq(expected)
 
         expect(validation_errors).to be_empty
+      end
+
+      it 'includes the digest value' do
+        hash = OpenSSL::Digest::SHA256.digest(c14n_xml)
+        expect(reference.find(:xpath, 'ds:DigestValue').text.strip)
+          .to eq(Base64.strict_encode64(hash))
       end
     end
 
@@ -124,19 +124,17 @@ RSpec.shared_examples 'ds:Signature xml' do
         e = reference.find(:xpath, 'ds:DigestMethod')
         expect(e['Algorithm']).to eq('http://www.w3.org/2001/04/xmlenc#sha256')
 
-        hash = OpenSSL::Digest::SHA256.digest(c14n_xml)
-        expected = Base64.strict_encode64(hash)
-
-        expect(reference.find(:xpath, 'ds:DigestValue').text.strip)
-          .to eq(expected)
-
         rsa_sig = key.sign(OpenSSL::Digest.new('SHA256'), c14n_signed_info)
-        expected = Base64.strict_encode64(rsa_sig).strip
-
         expect(signature.find(:xpath, 'ds:SignatureValue').text.strip)
-          .to eq(expected)
+          .to eq(Base64.strict_encode64(rsa_sig).strip)
 
         expect(validation_errors).to be_empty
+      end
+
+      it 'includes the digest value' do
+        hash = OpenSSL::Digest::SHA256.digest(c14n_xml)
+        expect(reference.find(:xpath, 'ds:DigestValue').text.strip)
+          .to eq(Base64.strict_encode64(hash))
       end
     end
   end

--- a/spec/support/metadata/signature.rb
+++ b/spec/support/metadata/signature.rb
@@ -19,18 +19,22 @@ RSpec.shared_examples 'ds:Signature xml' do
   end
 
   it 'has a <Signature> element, c14n method, reference element, signed, and transforms' do
+    ## has a <Signature> element
     e = signed_info.find(:xpath, 'ds:CanonicalizationMethod')
     transforms = reference.all(:xpath, 'ds:Transforms/ds:Transform')
                           .map { |transform| transform['Algorithm'] }
 
     expect(xml).to have_xpath(sig_xpath.to_s)
+    ## has algorithm
     expect(e['Algorithm']).to eq('http://www.w3.org/2001/10/xml-exc-c14n#')
     expect(signed_info).to have_xpath('ds:SignatureMethod', count: 1).and(
       have_xpath('ds:Reference', count: 1)
     ).and(
       have_xpath('ds:CanonicalizationMethod', count: 1)
     )
+    ## designates the root element to be signed
     expect(reference['URI']).to eq("##{subject.instance_id}")
+    ## transforms
     expect(reference).to have_xpath('ds:Transforms', count: 1).and(
       have_xpath('ds:Transforms/ds:Transform', count: 2)
     ).and(have_xpath('ds:DigestMethod', count: 1))
@@ -38,6 +42,7 @@ RSpec.shared_examples 'ds:Signature xml' do
       'http://www.w3.org/2000/09/xmldsig#enveloped-signature',
       'http://www.w3.org/2001/10/xml-exc-c14n#'
     )
+    ## xml elements
     expect(signature).to have_xpath('ds:KeyInfo', count: 1)
       .and have_xpath('ds:KeyInfo/ds:KeyValue', count: 1)
       .and have_xpath('ds:KeyInfo/ds:X509Data', count: 1)
@@ -56,6 +61,7 @@ RSpec.shared_examples 'ds:Signature xml' do
 
     expect(exponent).to eq(key.e.to_i)
 
+    ## has cerificate
     cert = [
       '-----BEGIN CERTIFICATE-----',
       signature.find(:xpath, './/ds:X509Certificate').text.strip,

--- a/spec/support/metadata/signature.rb
+++ b/spec/support/metadata/signature.rb
@@ -18,7 +18,7 @@ RSpec.shared_examples 'ds:Signature xml' do
     Base64.decode64(str).unpack('C*').reduce { |a, e| (a << 8) + e }
   end
 
-  it 'has a <Signature> element' do
+  it 'has a <Signature> element, c14n method, reference element, signed, and transforms' do
     e = signed_info.find(:xpath, 'ds:CanonicalizationMethod')
     transforms = reference.all(:xpath, 'ds:Transforms/ds:Transform')
                           .map { |transform| transform['Algorithm'] }

--- a/spec/support/metadata/sirtfi_contact_person.rb
+++ b/spec/support/metadata/sirtfi_contact_person.rb
@@ -15,9 +15,9 @@ RSpec.shared_examples 'SIRTFI ContactPerson xml' do
 
   it 'is created' do
     expect(xml).to have_xpath(contact_person_path, count: 1)
-      expect(node['contactType']).to eq('other')
-      expect(node['remd:contactType'])
-        .to eq('http://refeds.org/metadata/contactType/security')
+    expect(node['contactType']).to eq('other')
+    expect(node['remd:contactType'])
+      .to eq('http://refeds.org/metadata/contactType/security')
   end
 
   context 'Company' do

--- a/spec/support/metadata/sirtfi_contact_person.rb
+++ b/spec/support/metadata/sirtfi_contact_person.rb
@@ -15,17 +15,9 @@ RSpec.shared_examples 'SIRTFI ContactPerson xml' do
 
   it 'is created' do
     expect(xml).to have_xpath(contact_person_path, count: 1)
-  end
-
-  context 'attributes' do
-    it 'sets contactType' do
       expect(node['contactType']).to eq('other')
-    end
-
-    it 'sets remd:contactType' do
       expect(node['remd:contactType'])
         .to eq('http://refeds.org/metadata/contactType/security')
-    end
   end
 
   context 'Company' do
@@ -41,8 +33,6 @@ RSpec.shared_examples 'SIRTFI ContactPerson xml' do
     context 'when known' do
       it 'is created' do
         expect(xml).to have_xpath(contact_person_company_path, count: 1)
-      end
-      it 'has correct value' do
         expect(node.text).to eq(sirtfi_contact_person.contact.company)
       end
     end
@@ -61,8 +51,6 @@ RSpec.shared_examples 'SIRTFI ContactPerson xml' do
     context 'when known' do
       it 'is created' do
         expect(xml).to have_xpath(contact_person_given_name_path, count: 1)
-      end
-      it 'has correct value' do
         expect(node.text).to eq(sirtfi_contact_person.contact.given_name)
       end
     end
@@ -81,8 +69,6 @@ RSpec.shared_examples 'SIRTFI ContactPerson xml' do
     context 'when known' do
       it 'is created' do
         expect(xml).to have_xpath(contact_person_surname_path, count: 1)
-      end
-      it 'has correct value' do
         expect(node.text).to eq(sirtfi_contact_person.contact.surname)
       end
     end
@@ -101,8 +87,6 @@ RSpec.shared_examples 'SIRTFI ContactPerson xml' do
     context 'when known' do
       it 'is created' do
         expect(xml).to have_xpath(contact_person_email_address_path, count: 1)
-      end
-      it 'has correct value with uri prepended' do
         expect(node.text)
           .to eq("mailto:#{sirtfi_contact_person.contact.email_address}")
       end
@@ -123,8 +107,6 @@ RSpec.shared_examples 'SIRTFI ContactPerson xml' do
       it 'is created' do
         expect(xml)
           .to have_xpath(contact_person_telephone_number_path, count: 1)
-      end
-      it 'has correct value' do
         expect(node.text).to eq(sirtfi_contact_person.contact.telephone_number)
       end
     end

--- a/spec/support/metadata/sirtfi_contact_person.rb
+++ b/spec/support/metadata/sirtfi_contact_person.rb
@@ -13,7 +13,7 @@ RSpec.shared_examples 'SIRTFI ContactPerson xml' do
   end
   let(:node) { xml.first(:xpath, contact_person_path) }
 
-  it 'is created' do
+  it 'is created with contactType and remd:contactType' do
     expect(xml).to have_xpath(contact_person_path, count: 1)
     expect(node['contactType']).to eq('other')
     expect(node['remd:contactType'])
@@ -31,7 +31,7 @@ RSpec.shared_examples 'SIRTFI ContactPerson xml' do
       end
     end
     context 'when known' do
-      it 'is created' do
+      it 'is created with company' do
         expect(xml).to have_xpath(contact_person_company_path, count: 1)
         expect(node.text).to eq(sirtfi_contact_person.contact.company)
       end
@@ -49,7 +49,7 @@ RSpec.shared_examples 'SIRTFI ContactPerson xml' do
       end
     end
     context 'when known' do
-      it 'is created' do
+      it 'is created with contact person' do
         expect(xml).to have_xpath(contact_person_given_name_path, count: 1)
         expect(node.text).to eq(sirtfi_contact_person.contact.given_name)
       end
@@ -67,7 +67,7 @@ RSpec.shared_examples 'SIRTFI ContactPerson xml' do
       end
     end
     context 'when known' do
-      it 'is created' do
+      it 'is created with surname' do
         expect(xml).to have_xpath(contact_person_surname_path, count: 1)
         expect(node.text).to eq(sirtfi_contact_person.contact.surname)
       end
@@ -85,7 +85,7 @@ RSpec.shared_examples 'SIRTFI ContactPerson xml' do
       end
     end
     context 'when known' do
-      it 'is created' do
+      it 'is created with email' do
         expect(xml).to have_xpath(contact_person_email_address_path, count: 1)
         expect(node.text)
           .to eq("mailto:#{sirtfi_contact_person.contact.email_address}")
@@ -104,7 +104,7 @@ RSpec.shared_examples 'SIRTFI ContactPerson xml' do
       end
     end
     context 'when known' do
-      it 'is created' do
+      it 'is created with telephone' do
         expect(xml)
           .to have_xpath(contact_person_telephone_number_path, count: 1)
         expect(node.text).to eq(sirtfi_contact_person.contact.telephone_number)

--- a/spec/support/metadata/sp_sso_descriptor.rb
+++ b/spec/support/metadata/sp_sso_descriptor.rb
@@ -23,7 +23,7 @@ RSpec.shared_examples 'SPSSODescriptor xml' do
   context 'attributes' do
     let(:node) { xml.first(:xpath, sp_sso_descriptor_path) }
 
-    it 'is not rendered' do
+    it 'are not rendered' do
       expect(node['AuthnRequestsSigned']).to be_falsey
       expect(node['WantAssertionsSigned']).to be_falsey
     end

--- a/spec/support/metadata/sp_sso_descriptor.rb
+++ b/spec/support/metadata/sp_sso_descriptor.rb
@@ -29,36 +29,30 @@ RSpec.shared_examples 'SPSSODescriptor xml' do
     end
   end
 
-  context 'AssertionConsumerService' do
-    context 'multiple endpoints' do
-      let(:sp_sso_descriptor) do
-        create :sp_sso_descriptor, :with_multiple_assertion_consumer_services
-      end
-      it 'renders all' do
-        expect(xml).to have_xpath(assertion_consumer_service_path, count: 3)
-      end
+  context 'AssertionConsumerService multiple endpoints' do
+    let(:sp_sso_descriptor) do
+      create :sp_sso_descriptor, :with_multiple_assertion_consumer_services
+    end
+    it 'renders all' do
+      expect(xml).to have_xpath(assertion_consumer_service_path, count: 3)
     end
   end
 
-  context 'AttributeConsumingService' do
-    context 'when populated' do
-      let(:sp_sso_descriptor) do
-        create :sp_sso_descriptor, :with_attribute_consuming_services
-      end
-      it 'is rendered' do
-        expect(xml).to have_xpath(attribute_consuming_service_path, count: 2)
-      end
+  context 'AttributeConsumingService when populated' do
+    let(:sp_sso_descriptor) do
+      create :sp_sso_descriptor, :with_attribute_consuming_services
+    end
+    it 'is rendered' do
+      expect(xml).to have_xpath(attribute_consuming_service_path, count: 2)
     end
   end
 
-  context 'idpdisc:DiscoveryResponse' do
-    context 'when populated' do
-      let(:sp_sso_descriptor) do
-        create :sp_sso_descriptor, :with_discovery_response_services
-      end
-      it 'is rendered' do
-        expect(xml).to have_xpath(idpdisc_discovery_response_path, count: 1)
-      end
+  context 'idpdisc:DiscoveryResponse when populated' do
+    let(:sp_sso_descriptor) do
+      create :sp_sso_descriptor, :with_discovery_response_services
+    end
+    it 'is rendered' do
+      expect(xml).to have_xpath(idpdisc_discovery_response_path, count: 1)
     end
   end
 end

--- a/spec/support/metadata/sp_sso_descriptor.rb
+++ b/spec/support/metadata/sp_sso_descriptor.rb
@@ -23,16 +23,9 @@ RSpec.shared_examples 'SPSSODescriptor xml' do
   context 'attributes' do
     let(:node) { xml.first(:xpath, sp_sso_descriptor_path) }
 
-    context 'AuthnRequestsSigned' do
-      it 'is not rendered' do
-        expect(node['AuthnRequestsSigned']).to be_falsey
-      end
-    end
-
-    context 'WantAssertionsSigned' do
-      it 'is not rendered' do
-        expect(node['WantAssertionsSigned']).to be_falsey
-      end
+    it 'is not rendered' do
+      expect(node['AuthnRequestsSigned']).to be_falsey
+      expect(node['WantAssertionsSigned']).to be_falsey
     end
   end
 

--- a/spec/support/metadata/sp_sso_descriptor.rb
+++ b/spec/support/metadata/sp_sso_descriptor.rb
@@ -15,6 +15,9 @@ RSpec.shared_examples 'SPSSODescriptor xml' do
 
   it 'is created' do
     expect(xml).to have_xpath(sp_sso_descriptor_path)
+    expect(xml).to have_xpath(assertion_consumer_service_path, count: 1)
+    expect(xml).not_to have_xpath(attribute_consuming_service_path)
+    expect(xml).not_to have_xpath(idpdisc_discovery_response_path)
   end
 
   context 'attributes' do
@@ -34,10 +37,6 @@ RSpec.shared_examples 'SPSSODescriptor xml' do
   end
 
   context 'AssertionConsumerService' do
-    it 'is rendered' do
-      expect(xml).to have_xpath(assertion_consumer_service_path, count: 1)
-    end
-
     context 'multiple endpoints' do
       let(:sp_sso_descriptor) do
         create :sp_sso_descriptor, :with_multiple_assertion_consumer_services
@@ -49,11 +48,6 @@ RSpec.shared_examples 'SPSSODescriptor xml' do
   end
 
   context 'AttributeConsumingService' do
-    context 'when not populated' do
-      it 'is not rendered' do
-        expect(xml).not_to have_xpath(attribute_consuming_service_path)
-      end
-    end
     context 'when populated' do
       let(:sp_sso_descriptor) do
         create :sp_sso_descriptor, :with_attribute_consuming_services
@@ -65,11 +59,6 @@ RSpec.shared_examples 'SPSSODescriptor xml' do
   end
 
   context 'idpdisc:DiscoveryResponse' do
-    context 'when not populated' do
-      it 'is not rendered' do
-        expect(xml).not_to have_xpath(idpdisc_discovery_response_path)
-      end
-    end
     context 'when populated' do
       let(:sp_sso_descriptor) do
         create :sp_sso_descriptor, :with_discovery_response_services

--- a/spec/support/metadata/sso_role_descriptor.rb
+++ b/spec/support/metadata/sso_role_descriptor.rb
@@ -14,7 +14,7 @@ RSpec.shared_examples 'SSODescriptor xml' do
     "#{sso_descriptor_path}/NameIDFormat"
   end
 
-  it 'is created' do
+  it 'is created without sso, name_id and artificat resolution' do
     expect(xml).to have_xpath(sso_descriptor_path)
     expect(xml).not_to have_xpath(artifact_resolution_service_path)
     expect(xml).not_to have_xpath(single_logout_service_path)
@@ -54,7 +54,7 @@ RSpec.shared_examples 'SSODescriptor xml' do
     let(:sso_descriptor) do
       create parent_node, :with_name_id_formats
     end
-    it 'is rendered' do
+    it 'is rendered with nameid' do
       expect(xml).to have_xpath(name_id_format_path, count: 2)
       expect(node.text).to eq(sso_descriptor.name_id_formats.first.uri)
     end

--- a/spec/support/metadata/sso_role_descriptor.rb
+++ b/spec/support/metadata/sso_role_descriptor.rb
@@ -16,14 +16,13 @@ RSpec.shared_examples 'SSODescriptor xml' do
 
   it 'is created' do
     expect(xml).to have_xpath(sso_descriptor_path)
+    expect(xml).not_to have_xpath(artifact_resolution_service_path)
+    expect(xml).not_to have_xpath(single_logout_service_path)
+    expect(xml).not_to have_xpath(manage_name_id_service_path)
+    expect(xml).not_to have_xpath(name_id_format_path)
   end
 
   context 'ArtifactResolutionService' do
-    context 'when not populated' do
-      it 'is not rendered' do
-        expect(xml).not_to have_xpath(artifact_resolution_service_path)
-      end
-    end
     context 'when populated' do
       let(:sso_descriptor) do
         create parent_node, :with_artifact_resolution_services
@@ -35,11 +34,6 @@ RSpec.shared_examples 'SSODescriptor xml' do
   end
 
   context 'SingleLogoutService' do
-    context 'when not populated' do
-      it 'is not rendered' do
-        expect(xml).not_to have_xpath(single_logout_service_path)
-      end
-    end
     context 'when populated' do
       let(:sso_descriptor) do
         create parent_node, :with_single_logout_services
@@ -51,11 +45,6 @@ RSpec.shared_examples 'SSODescriptor xml' do
   end
 
   context 'ManageNameIDService' do
-    context 'when not populated' do
-      it 'is not rendered' do
-        expect(xml).not_to have_xpath(manage_name_id_service_path)
-      end
-    end
     context 'when populated' do
       let(:sso_descriptor) do
         create parent_node, :with_manage_name_id_services
@@ -67,11 +56,6 @@ RSpec.shared_examples 'SSODescriptor xml' do
   end
 
   context 'NameIDFormat' do
-    context 'when not populated' do
-      it 'is not rendered' do
-        expect(xml).not_to have_xpath(name_id_format_path)
-      end
-    end
     context 'when populated' do
       let(:node) { xml.first(:xpath, name_id_format_path) }
       let(:sso_descriptor) do
@@ -79,8 +63,6 @@ RSpec.shared_examples 'SSODescriptor xml' do
       end
       it 'is rendered' do
         expect(xml).to have_xpath(name_id_format_path, count: 2)
-      end
-      it 'has expected value' do
         expect(node.text).to eq(sso_descriptor.name_id_formats.first.uri)
       end
     end

--- a/spec/support/metadata/sso_role_descriptor.rb
+++ b/spec/support/metadata/sso_role_descriptor.rb
@@ -22,49 +22,41 @@ RSpec.shared_examples 'SSODescriptor xml' do
     expect(xml).not_to have_xpath(name_id_format_path)
   end
 
-  context 'ArtifactResolutionService' do
-    context 'when populated' do
-      let(:sso_descriptor) do
-        create parent_node, :with_artifact_resolution_services
-      end
-      it 'is rendered' do
-        expect(xml).to have_xpath(artifact_resolution_service_path, count: 2)
-      end
+  context 'ArtifactResolutionService when populated' do
+    let(:sso_descriptor) do
+      create parent_node, :with_artifact_resolution_services
+    end
+    it 'is rendered' do
+      expect(xml).to have_xpath(artifact_resolution_service_path, count: 2)
     end
   end
 
-  context 'SingleLogoutService' do
-    context 'when populated' do
-      let(:sso_descriptor) do
-        create parent_node, :with_single_logout_services
-      end
-      it 'is rendered' do
-        expect(xml).to have_xpath(single_logout_service_path, count: 2)
-      end
+  context 'SingleLogoutService when populated' do
+    let(:sso_descriptor) do
+      create parent_node, :with_single_logout_services
+    end
+    it 'is rendered' do
+      expect(xml).to have_xpath(single_logout_service_path, count: 2)
     end
   end
 
-  context 'ManageNameIDService' do
-    context 'when populated' do
-      let(:sso_descriptor) do
-        create parent_node, :with_manage_name_id_services
-      end
-      it 'is rendered' do
-        expect(xml).to have_xpath(manage_name_id_service_path, count: 2)
-      end
+  context 'ManageNameIDService when populated' do
+    let(:sso_descriptor) do
+      create parent_node, :with_manage_name_id_services
+    end
+    it 'is rendered' do
+      expect(xml).to have_xpath(manage_name_id_service_path, count: 2)
     end
   end
 
-  context 'NameIDFormat' do
-    context 'when populated' do
-      let(:node) { xml.first(:xpath, name_id_format_path) }
-      let(:sso_descriptor) do
-        create parent_node, :with_name_id_formats
-      end
-      it 'is rendered' do
-        expect(xml).to have_xpath(name_id_format_path, count: 2)
-        expect(node.text).to eq(sso_descriptor.name_id_formats.first.uri)
-      end
+  context 'NameIDFormat when populated' do
+    let(:node) { xml.first(:xpath, name_id_format_path) }
+    let(:sso_descriptor) do
+      create parent_node, :with_name_id_formats
+    end
+    it 'is rendered' do
+      expect(xml).to have_xpath(name_id_format_path, count: 2)
+      expect(node.text).to eq(sso_descriptor.name_id_formats.first.uri)
     end
   end
 end

--- a/spec/support/metadata/sso_role_descriptor.rb
+++ b/spec/support/metadata/sso_role_descriptor.rb
@@ -14,7 +14,7 @@ RSpec.shared_examples 'SSODescriptor xml' do
     "#{sso_descriptor_path}/NameIDFormat"
   end
 
-  it 'is created without sso, name_id and artificat resolution' do
+  it 'is created without sso, name_id and artifact resolution' do
     expect(xml).to have_xpath(sso_descriptor_path)
     expect(xml).not_to have_xpath(artifact_resolution_service_path)
     expect(xml).not_to have_xpath(single_logout_service_path)

--- a/spec/support/models.rb
+++ b/spec/support/models.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 shared_examples 'a basic model' do
-  it { is_expected.to validate_presence :created_at }
-  it { is_expected.to validate_presence :updated_at }
+  it do
+    is_expected.to validate_presence :created_at
+    is_expected.to validate_presence :updated_at
+  end
 end

--- a/spec/support/models.rb
+++ b/spec/support/models.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 shared_examples 'a basic model' do
-  it do
-    is_expected.to validate_presence :created_at
-    is_expected.to validate_presence :updated_at
-  end
+  it { is_expected.to validate_presence :created_at }
+  it { is_expected.to validate_presence :updated_at }
 end

--- a/spec/support/taggable.rb
+++ b/spec/support/taggable.rb
@@ -25,8 +25,10 @@ shared_examples 'a taggable model' do |tag_factory, association|
         create(tag_factory,
                factory_args(tag_name, instance, association))
       end
-      it { is_expected.to contain_exactly(instance) }
-      it { is_expected.to contain_exactly(an_instance_of(described_class)) }
+      it {
+        is_expected.to contain_exactly(instance)
+        is_expected.to contain_exactly(an_instance_of(described_class))
+      }
     end
 
     context "when a tag exists for multiple #{described_class.name}" do
@@ -37,8 +39,8 @@ shared_examples 'a taggable model' do |tag_factory, association|
         create(tag_factory, factory_args(tag_name,
                                          another_instance, association))
       end
-      it { is_expected.to contain_exactly(instance, another_instance) }
       it "should contain two instances of #{described_class}" do
+        is_expected.to contain_exactly(instance, another_instance)
         expect(subject).to contain_exactly(an_instance_of(described_class),
                                            an_instance_of(described_class))
       end
@@ -55,8 +57,10 @@ shared_examples 'a taggable model' do |tag_factory, association|
                                          association))
       end
 
-      it { is_expected.to contain_exactly(instance) }
-      it { is_expected.to contain_exactly(an_instance_of(described_class)) }
+      it {
+        is_expected.to contain_exactly(instance)
+        is_expected.to contain_exactly(an_instance_of(described_class))
+      }
     end
 
     context "with a tag amongst many #{described_class.name}" do
@@ -71,8 +75,10 @@ shared_examples 'a taggable model' do |tag_factory, association|
                                          association))
       end
 
-      it { is_expected.to contain_exactly(instance) }
-      it { is_expected.to contain_exactly(an_instance_of(described_class)) }
+      it { 
+        is_expected.to contain_exactly(instance) 
+        is_expected.to contain_exactly(an_instance_of(described_class))
+      }
     end
   end
 
@@ -91,8 +97,10 @@ shared_examples 'a taggable model' do |tag_factory, association|
         before do
           create(tag_factory, factory_args(tag_name, instance, association))
         end
-        it { is_expected.to contain_exactly(instance) }
-        it { is_expected.to contain_exactly(an_instance_of(described_class)) }
+        it { 
+          is_expected.to contain_exactly(instance) 
+          is_expected.to contain_exactly(an_instance_of(described_class))
+        }
       end
 
       context "when multiple #{described_class.name} associations exists" do
@@ -102,8 +110,8 @@ shared_examples 'a taggable model' do |tag_factory, association|
           create(tag_factory, factory_args(tag_name,
                                            another_instance, association))
         end
-        it { is_expected.to contain_exactly(instance, another_instance) }
         it "should contain two instances of #{described_class}" do
+          is_expected.to contain_exactly(instance, another_instance)
           expect(subject).to contain_exactly(an_instance_of(described_class),
                                              an_instance_of(described_class))
         end
@@ -126,8 +134,10 @@ shared_examples 'a taggable model' do |tag_factory, association|
                                            association))
         end
 
-        it { is_expected.to contain_exactly(instance) }
-        it { is_expected.to contain_exactly(an_instance_of(described_class)) }
+        it { 
+          is_expected.to contain_exactly(instance)
+          is_expected.to contain_exactly(an_instance_of(described_class))
+         }
       end
 
       context "with a #{described_class.name} associated with one tag only" do
@@ -168,8 +178,6 @@ shared_examples 'a taggable model' do |tag_factory, association|
         it "should contain all #{described_class} instances" do
           expect(subject).to contain_exactly(instance, another_instance_1,
                                              another_instance_2)
-        end
-        it "should contain three instances of #{described_class}" do
           expect(subject).to contain_exactly(an_instance_of(described_class),
                                              an_instance_of(described_class),
                                              an_instance_of(described_class))

--- a/spec/support/taggable.rb
+++ b/spec/support/taggable.rb
@@ -75,8 +75,8 @@ shared_examples 'a taggable model' do |tag_factory, association|
                                          association))
       end
 
-      it { 
-        is_expected.to contain_exactly(instance) 
+      it {
+        is_expected.to contain_exactly(instance)
         is_expected.to contain_exactly(an_instance_of(described_class))
       }
     end
@@ -97,8 +97,8 @@ shared_examples 'a taggable model' do |tag_factory, association|
         before do
           create(tag_factory, factory_args(tag_name, instance, association))
         end
-        it { 
-          is_expected.to contain_exactly(instance) 
+        it {
+          is_expected.to contain_exactly(instance)
           is_expected.to contain_exactly(an_instance_of(described_class))
         }
       end
@@ -134,10 +134,10 @@ shared_examples 'a taggable model' do |tag_factory, association|
                                            association))
         end
 
-        it { 
+        it {
           is_expected.to contain_exactly(instance)
           is_expected.to contain_exactly(an_instance_of(described_class))
-         }
+        }
       end
 
       context "with a #{described_class.name} associated with one tag only" do

--- a/spec/support/taggable.rb
+++ b/spec/support/taggable.rb
@@ -16,9 +16,7 @@ shared_examples 'a taggable model' do |tag_factory, association|
 
     subject { described_class.with_any_tag(tag_name) }
 
-    context 'when no tags exist' do
-      it { is_expected.to eq([]) }
-    end
+    it { is_expected.to eq([]) }
 
     context 'when an associated tag exists' do
       before do
@@ -89,9 +87,7 @@ shared_examples 'a taggable model' do |tag_factory, association|
     context 'with a single argument' do
       subject { described_class.with_all_tags(tag_name) }
 
-      context 'when no associations exist' do
-        it { is_expected.to eq([]) }
-      end
+      it { is_expected.to eq([]) }
 
       context "when a single #{described_class.name} association exists" do
         before do
@@ -123,9 +119,7 @@ shared_examples 'a taggable model' do |tag_factory, association|
 
       subject { described_class.with_all_tags([tag_name, another_tag_name]) }
 
-      context 'when no associations exist' do
-        it { is_expected.to eq([]) }
-      end
+      it { is_expected.to eq([]) }
 
       context "with a #{described_class.name} associated with all tags" do
         before do


### PR DESCRIPTION
(ignore the failing tests for now)
This was from a run reducing just the ETL tests, and there is still improvements that could be done by chaining .and most are just merged it blocks where context is no different between tests.

The one downside to this change is the context/it blocks that are removed that may provide more information to a dev.

While this time taken might not feel like much, it would proably get better by performing such adjustments across the whole test suite, also locally for some reason the entire suite can take ~25 minutes on my machine so hoping these changes improve this also

Before:
Finished in 4 minutes 11.3 seconds (files took 4.85 seconds to load)
2098 examples, 0 failures
After:
Finished in 3 minutes 46.7 seconds (files took 6.48 seconds to load)
1654 examples, 0 failures