### PR TITLE
Filter specific entity requests by tag

### DIFF
--- a/app/controllers/metadata_query_controller.rb
+++ b/app/controllers/metadata_query_controller.rb
@@ -25,18 +25,19 @@ class MetadataQueryController < ApplicationController
   end
 
   def specific_entity
-    handle_entity_request(select_entity_by_rank(EntityId.where(uri: params[:identifier]).all))
+    handle_entity_request(select_entity_with_tag_by_rank(EntityId.where(uri: params[:identifier]).all))
   end
 
   def specific_entity_sha1
     sha1_identifier = params[:identifier].match(SHA1_REGEX)
-    handle_entity_request(select_entity_by_rank(EntityId.where(sha1: sha1_identifier[1]).all))
+    handle_entity_request(select_entity_with_tag_by_rank(EntityId.where(sha1: sha1_identifier[1]).all))
   end
 
   private
 
-  def select_entity_by_rank(entity_ids)
-    entity_ids.min_by { |e| e.parent.known_entity.entity_source.rank }
+  def select_entity_with_tag_by_rank(entity_ids)
+    entity_ids.select { |e| e.parent.known_entity.tags.map(&:name).include?(@metadata_instance.primary_tag) }
+              .min_by { |e| e.parent.known_entity.entity_source.rank }
   end
 
   def handle_entities_request(tags)

--- a/spec/controllers/metadata_query_controller_spec.rb
+++ b/spec/controllers/metadata_query_controller_spec.rb
@@ -294,6 +294,12 @@ RSpec.describe MetadataQueryController, type: :controller do
   end
 
   describe '#specific_entity' do
+    let(:entity_source) do
+      es = create(:basic_federation)
+      create :derived_tag, tag_name: primary_tag, when_tags: es.source_tag, unless_tags: ''
+      es
+    end
+
     RSpec.shared_examples 'Specific Entity Descriptor' do
       context 'GET' do
         before { request.accept = saml_content }
@@ -476,12 +482,15 @@ RSpec.describe MetadataQueryController, type: :controller do
     RSpec.shared_examples 'EntityDescriptors from multiple sources' do
       before { request.accept = saml_content }
 
-      let(:entity_source) { create :basic_federation }
       let(:sp) { create :basic_federation_entity, :sp, entity_source: entity_source }
       let(:entity_descriptor) { sp.entity_descriptor }
       let(:entity_id) { entity_descriptor.entity_id.uri }
 
-      let(:external_entity_source) { create :entity_source, rank: entity_source.rank + 1 }
+      let(:external_entity_source) do
+        es = create(:entity_source, rank: entity_source.rank + 1)
+        create :derived_tag, tag_name: primary_tag, when_tags: es.source_tag, unless_tags: ''
+        es
+      end
       let(:external_sp) do
         create :basic_federation_entity, :sp, entity_source: external_entity_source
       end
@@ -523,15 +532,16 @@ RSpec.describe MetadataQueryController, type: :controller do
       end
 
       context 'EntityDescriptor' do
-        let(:idp_sso_descriptor) { create :idp_sso_descriptor }
-        let(:entity_descriptor) { idp_sso_descriptor.entity_descriptor }
+        let(:known_entity) { create(:known_entity, :with_idp, entity_source: entity_source) }
+        let(:entity_descriptor) { known_entity.entity_descriptor }
         let(:entity_id) { entity_descriptor.entity_id.uri }
 
         include_examples 'Specific Entity Descriptor'
       end
 
       context 'RawEntityDescriptor' do
-        let(:entity_descriptor) { create :raw_entity_descriptor }
+        let(:known_entity) { create(:known_entity, entity_source: entity_source) }
+        let(:entity_descriptor) { create(:raw_entity_descriptor, known_entity: known_entity) }
         let(:entity_id) { entity_descriptor.entity_id.uri }
 
         include_examples 'Specific Entity Descriptor'
@@ -552,15 +562,16 @@ RSpec.describe MetadataQueryController, type: :controller do
       end
 
       context 'EntityDescriptor' do
-        let(:idp_sso_descriptor) { create :idp_sso_descriptor }
-        let(:entity_descriptor) { idp_sso_descriptor.entity_descriptor }
+        let(:known_entity) { create(:known_entity, :with_idp, entity_source: entity_source) }
+        let(:entity_descriptor) { known_entity.entity_descriptor }
         let(:entity_id) { entity_descriptor.entity_id.uri }
 
         include_examples 'Specific Entity Descriptor'
       end
 
       context 'RawEntityDescriptor' do
-        let(:entity_descriptor) { create :raw_entity_descriptor }
+        let(:known_entity) { create(:known_entity, entity_source: entity_source) }
+        let(:entity_descriptor) { create(:raw_entity_descriptor, known_entity: known_entity) }
         let(:entity_id) { entity_descriptor.entity_id.uri }
 
         include_examples 'Specific Entity Descriptor'

--- a/spec/factories/known_entities.rb
+++ b/spec/factories/known_entities.rb
@@ -22,5 +22,9 @@ FactoryBot.define do
         ke.raw_entity_descriptor = red
       end
     end
+
+    after(:create) do |ke|
+      ke.tag_as(ke.entity_source.source_tag)
+    end
   end
 end

--- a/spec/models/edugain/identity_provider_export_spec.rb
+++ b/spec/models/edugain/identity_provider_export_spec.rb
@@ -10,13 +10,13 @@ describe Edugain::IdentityProviderExport do
       let(:entity_descriptor) { create(:entity_descriptor, :with_idp) }
       let(:entity_id) { entity_descriptor.entity_id.uri }
 
-      it 'tags the KnownEntity as aaf-edugain-verified' do
-        expect(entity_descriptor.known_entity.tags).to be_empty
+      it 'tags the KnownEntity as aaf-edugain-export' do
+        expect(entity_descriptor.known_entity.tags.map(&:name)).not_to include 'aaf-edugain-export'
 
         save
         entity_descriptor.reload
 
-        expect(entity_descriptor.known_entity.tags.first.name).to eq 'aaf-edugain-export'
+        expect(entity_descriptor.known_entity.tags.map(&:name)).to include 'aaf-edugain-export'
       end
 
       it 'adds attributes for Edugain' do

--- a/spec/models/edugain/non_research_and_scholarship_entity_spec.rb
+++ b/spec/models/edugain/non_research_and_scholarship_entity_spec.rb
@@ -11,12 +11,12 @@ describe Edugain::NonResearchAndScholarshipEntity do
       let(:id) { entity_descriptor.entity_id.uri }
 
       it 'tags the KnownEntity as aaf-edugain-verified' do
-        expect(entity_descriptor.known_entity.tags).to be_empty
+        expect(entity_descriptor.known_entity.tags.map(&:name)).not_to include 'aaf-edugain-verified'
 
         approve
         entity_descriptor.reload
 
-        expect(entity_descriptor.known_entity.tags.first.name).to eq 'aaf-edugain-verified'
+        expect(entity_descriptor.known_entity.tags.map(&:name)).to include 'aaf-edugain-verified'
       end
     end
 
@@ -25,12 +25,12 @@ describe Edugain::NonResearchAndScholarshipEntity do
       let(:id) { entity_descriptor.entity_id.uri }
 
       it 'tags the KnownEntity as aaf-edugain-verified' do
-        expect(entity_descriptor.known_entity.tags).to be_empty
+        expect(entity_descriptor.known_entity.tags.map(&:name)).not_to include 'aaf-edugain-verified'
 
         approve
         entity_descriptor.reload
 
-        expect(entity_descriptor.known_entity.tags.first.name).to eq 'aaf-edugain-verified'
+        expect(entity_descriptor.known_entity.tags.map(&:name)).to include 'aaf-edugain-verified'
       end
     end
 

--- a/spec/models/edugain/service_provider_export_spec.rb
+++ b/spec/models/edugain/service_provider_export_spec.rb
@@ -21,12 +21,12 @@ describe Edugain::ServiceProviderExport do
         end
 
         it 'tags the KnownEntity as aaf-edugain-verified' do
-          expect(entity_descriptor.known_entity.tags).to be_empty
+          expect(entity_descriptor.known_entity.tags.map(&:name)).not_to include 'aaf-edugain-export'
 
           save
           entity_descriptor.reload
 
-          expect(entity_descriptor.known_entity.tags.first.name).to eq 'aaf-edugain-export'
+          expect(entity_descriptor.known_entity.tags.map(&:name)).to include 'aaf-edugain-export'
         end
 
         it 'adds attributes for Edugain' do

--- a/spec/models/known_entity_spec.rb
+++ b/spec/models/known_entity_spec.rb
@@ -194,11 +194,11 @@ RSpec.describe KnownEntity do
     end
 
     def tag_names
-      Tag.where(known_entity_id: known_entity.id).all.map(&:name)
+      known_entity.reload.tags.map(&:name)
     end
 
     def create_derived_tag
-      known_entity.add_tag(name: derived_tag_name, derived: true)
+      known_entity.reload.add_tag(name: derived_tag_name, derived: true)
     end
 
     context 'when the tags are present' do

--- a/spec/requests/api/discovery_entities_spec.rb
+++ b/spec/requests/api/discovery_entities_spec.rb
@@ -8,23 +8,10 @@ RSpec.describe API::DiscoveryEntitiesController, type: :request do
   let(:json) { JSON.parse(response.body, symbolize_names: true) }
 
   shared_examples 'a discovery entity' do
-    it 'includes the entity id and no tags' do
+    it 'includes the entity id and tags' do
       expect(subject.pluck(:entity_id))
         .to include(entity.entity_id.uri)
-      expect(entry[:tags]).to eq([])
-    end
-
-    context 'with tags on the known entity' do
-      let!(:tags) do
-        %w[tag_a tag_b tag_c].map do |tag|
-          create(:known_entity_tag,
-                 name: tag, known_entity: entity.known_entity)
-        end
-      end
-
-      it 'returns the tags' do
-        expect(entry[:tags]).to contain_exactly('tag_a', 'tag_b', 'tag_c')
-      end
+      expect(entry[:tags]).to match_array(entity.known_entity.tags.map(&:name))
     end
 
     context 'with no mdui info' do

--- a/spec/requests/api/edugain/identity_provider_exports_spec.rb
+++ b/spec/requests/api/edugain/identity_provider_exports_spec.rb
@@ -15,13 +15,13 @@ RSpec.describe API::Edugain::IdentityProviderExportsController, type: :request d
            headers: { Authorization: +"Bearer #{api_subject.token}" }
     end
 
-    it 'tags the KnownEntity as aaf-edugain-verified' do
-      expect(entity_descriptor.known_entity.tags).to be_empty
+    it 'tags the KnownEntity as aaf-edugain-export' do
+      expect(entity_descriptor.known_entity.tags.map(&:name)).not_to include 'aaf-edugain-export'
 
       run
       entity_descriptor.reload
 
-      expect(entity_descriptor.known_entity.tags.first.name).to eq 'aaf-edugain-export'
+      expect(entity_descriptor.known_entity.tags.map(&:name)).to include 'aaf-edugain-export'
     end
 
     it 'adds attributes for Edugain' do

--- a/spec/requests/api/edugain/non_research_and_scholarship_entity_approvals_spec.rb
+++ b/spec/requests/api/edugain/non_research_and_scholarship_entity_approvals_spec.rb
@@ -16,12 +16,12 @@ RSpec.describe API::Edugain::NonResearchAndScholarshipEntityApprovalsController,
     end
 
     it 'tags the KnownEntity as aaf-edugain-verified' do
-      expect(entity_descriptor.known_entity.tags).to be_empty
+      expect(entity_descriptor.known_entity.tags.map(&:name)).not_to include 'aaf-edugain-verified'
 
       run
       entity_descriptor.reload
 
-      expect(entity_descriptor.known_entity.tags.first.name).to eq 'aaf-edugain-verified'
+      expect(entity_descriptor.known_entity.tags.map(&:name)).to include 'aaf-edugain-verified'
       expect(response).to have_http_status :no_content
     end
   end

--- a/spec/requests/api/edugain/service_provider_exports_spec.rb
+++ b/spec/requests/api/edugain/service_provider_exports_spec.rb
@@ -16,13 +16,13 @@ RSpec.describe API::Edugain::ServiceProviderExportsController, type: :request do
            headers: { Authorization: +"Bearer #{api_subject.token}" }
     end
 
-    it 'tags the KnownEntity as aaf-edugain-verified' do
-      expect(entity_descriptor.known_entity.tags).to be_empty
+    it 'tags the KnownEntity as aaf-edugain-export' do
+      expect(entity_descriptor.known_entity.tags.map(&:name)).not_to include 'aaf-edugain-export'
 
       run
       entity_descriptor.reload
 
-      expect(entity_descriptor.known_entity.tags.first.name).to eq 'aaf-edugain-export'
+      expect(entity_descriptor.known_entity.tags.map(&:name)).to include 'aaf-edugain-export'
     end
 
     it 'adds attributes for Edugain' do

--- a/spec/support/jobs/concerns/etl/attribute_authorities.rb
+++ b/spec/support/jobs/concerns/etl/attribute_authorities.rb
@@ -153,7 +153,7 @@ RSpec.shared_examples 'ETL::AttributeAuthorities' do
 
   let(:attributes) { attributes_list }
 
-  let(:entity_descriptor) { create :entity_descriptor }
+  let!(:entity_descriptor) { create :entity_descriptor }
 
   let(:ed_data) do
     {

--- a/spec/support/jobs/concerns/etl/identity_providers.rb
+++ b/spec/support/jobs/concerns/etl/identity_providers.rb
@@ -124,7 +124,7 @@ RSpec.shared_examples 'ETL::IdentityProviders' do
 
   let(:attributes) { attributes_list }
 
-  let(:entity_descriptor) { create :entity_descriptor }
+  let!(:entity_descriptor) { create :entity_descriptor }
 
   let(:ed_data) do
     {

--- a/spec/support/jobs/concerns/etl/service_providers.rb
+++ b/spec/support/jobs/concerns/etl/service_providers.rb
@@ -117,7 +117,7 @@ RSpec.shared_examples 'ETL::ServiceProviders' do
 
   let(:sp_created_at) { Time.zone.at(rand(Time.now.utc.to_i)) }
 
-  let(:entity_descriptor) { create :entity_descriptor }
+  let!(:entity_descriptor) { create :entity_descriptor }
 
   let(:ed_data) do
     {


### PR DESCRIPTION
A request /mdq/aaf-edugain-export/entities will return every entity we're exporting to eduGAIN. That's great! What's not so great is that a request for /mdq/aaf-edugain-export/{sha256}xyzabc will return the xyzabc entity regardless of whether we're exporting it to eduGAIN or not. SAML service just ignores the prefix and returns any entity in it's database.

This commit changes the behaviour so that it only returns an entity under a specific tag if the entity actually has that tag.

This is useful for the FR -> FM migration so we can confirm whether SAML service is aware of FM's copy of the data.